### PR TITLE
feat: Add agent module for shared utilities

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,17 @@
+"""Shared agent utilities for the Kubeflow Docs Assistant."""
+
+from .config import (
+    KSERVE_URL,
+    MODEL,
+    PORT,
+    MILVUS_HOST,
+    MILVUS_PORT,
+    MILVUS_COLLECTION,
+    MILVUS_VECTOR_FIELD,
+    EMBEDDING_MODEL,
+)
+from .prompts import SYSTEM_PROMPT
+from .tools import TOOLS
+from .rag import milvus_search, execute_tool
+
+

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,24 @@
+"""Centralized configuration for the docs-agent."""
+
+import os
+
+# KServe Config
+KSERVE_URL = os.getenv(
+    "KSERVE_URL",
+    "http://llama.santhosh.svc.cluster.local/openai/v1/chat/completions"
+)
+MODEL = os.getenv("MODEL", "llama3.1-8B")
+PORT = int(os.getenv("PORT", "8000"))
+
+# Milvus Config
+MILVUS_HOST = os.getenv(
+    "MILVUS_HOST",
+    "my-release-milvus.santhosh.svc.cluster.local"
+)
+MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
+MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
+EMBEDDING_MODEL = os.getenv(
+    "EMBEDDING_MODEL",
+    "sentence-transformers/all-mpnet-base-v2"
+)

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -1,0 +1,42 @@
+"""System prompts for the Kubeflow Docs Assistant."""
+
+SYSTEM_PROMPT = """
+You are the Kubeflow Docs Assistant.
+
+!!IMPORTANT!!
+- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documenation specific and relevant.
+- You should never output the raw tool call to the user.
+
+Your role
+- Always answer the user's question directly.
+- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
+- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
+
+Tool Use
+- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
+- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
+- When you do call the tool:
+  • Use one clear, focused query.  
+  • Summarize the result in your own words.  
+  • If no results are relevant, say "not found in the docs" and suggest refining the query.
+- Example usage:
+  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
+  - You should make a tool call to search the docs with a query "kubeflow setup".
+
+  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
+  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
+
+The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documenation specific and relevant.
+
+Routing
+- Greetings/small talk → respond briefly, no tool.  
+- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
+- Kubeflow-specific → answer and call the tool if documentation is needed.  
+
+Style
+- Be concise (2–5 sentences). Use bullet points or steps when helpful.
+- Provide examples only when asked.
+- Never invent features. If unsure, say so.
+- Reply in clean Markdown.
+"""
+

--- a/agent/rag.py
+++ b/agent/rag.py
@@ -1,0 +1,96 @@
+"""RAG utilities for Milvus search and tool execution."""
+
+import json
+from typing import Dict, Any, List, Tuple
+
+from sentence_transformers import SentenceTransformer
+from pymilvus import connections, Collection
+
+from .config import (
+    MILVUS_HOST,
+    MILVUS_PORT,
+    MILVUS_COLLECTION,
+    MILVUS_VECTOR_FIELD,
+    EMBEDDING_MODEL,
+)
+
+
+def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
+    """Execute a semantic search in Milvus and return structured JSON serializable results."""
+    try:
+        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
+        collection = Collection(MILVUS_COLLECTION)
+        collection.load()
+
+        encoder = SentenceTransformer(EMBEDDING_MODEL)
+        query_vec = encoder.encode(query).tolist()
+
+        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
+        results = collection.search(
+            data=[query_vec],
+            anns_field=MILVUS_VECTOR_FIELD,
+            param=search_params,
+            limit=int(top_k),
+            output_fields=["file_path", "content_text", "citation_url"],
+        )
+
+        hits = []
+        for hit in results[0]:
+            similarity = 1.0 - float(hit.distance)
+            entity = hit.entity
+            content_text = entity.get("content_text") or ""
+            if isinstance(content_text, str) and len(content_text) > 400:
+                content_text = content_text[:400] + "..."
+            hits.append({
+                "similarity": similarity,
+                "file_path": entity.get("file_path"),
+                "citation_url": entity.get("citation_url"),
+                "content_text": content_text,
+            })
+        return {"results": hits}
+    except Exception as e:
+        print(f"[ERROR] Milvus search failed: {e}")
+        return {"results": []}
+    finally:
+        try:
+            connections.disconnect(alias="default")
+        except Exception:
+            pass
+
+
+async def execute_tool(tool_call: Dict[str, Any]) -> Tuple[str, List[str]]:
+    """Execute a tool call and return the result and citations."""
+    try:
+        function_name = tool_call.get("function", {}).get("name")
+        arguments = json.loads(tool_call.get("function", {}).get("arguments", "{}"))
+
+        if function_name == "search_kubeflow_docs":
+            query = arguments.get("query", "")
+            top_k = arguments.get("top_k", 5)
+
+            print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
+            result = milvus_search(query, 15)
+
+            citations = []
+            formatted_results = []
+
+            for hit in result.get("results", []):
+                citation_url = hit.get("citation_url", "")
+                if citation_url and citation_url not in citations:
+                    citations.append(citation_url)
+
+                formatted_results.append(
+                    f"File: {hit.get('file_path', 'Unknown')}\n"
+                    f"Content: {hit.get('content_text', '')}\n"
+                    f"URL: {citation_url}\n"
+                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
+                )
+
+            formatted_text = "\n".join(formatted_results) if formatted_results else "No relevant results found."
+            return formatted_text, citations
+
+        return f"Unknown tool: {function_name}", []
+
+    except Exception as e:
+        print(f"[ERROR] Tool execution failed: {e}")
+        return f"Tool execution failed: {e}", []

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -1,0 +1,34 @@
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_kubeflow_docs",
+            "description": (
+                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
+                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
+                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
+                        "minLength": 1
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 10
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": False
+            }
+        }
+    }
+]


### PR DESCRIPTION
## Summary
Adds an `agent-app/` module to centralize shared utilities, preparing the codebase for agentic workflows.

## Changes
- [agent/config.py](cci:7://file:///home/g/Documents/contrib/docs-agent/agent/config.py:0:0-0:0) - Centralized environment variables
- [agent/prompts.py](cci:7://file:///home/g/Documents/contrib/docs-agent/agent/prompts.py:0:0-0:0) - System prompt and tool definitions
- [agent/rag.py](cci:7://file:///home/g/Documents/contrib/docs-agent/agent/rag.py:0:0-0:0) - Milvus search and tool execution
## Motivation
This prepares for the GSoC Agentic RAG proposal by making tool definitions modular and reusable.
## Future Work
- Update [server-https/app.py](cci:7://file:///home/g/Documents/contrib/docs-agent/server-https/app.py:0:0-0:0) to import from `agent/`
- 