### PR TITLE
Add Kubeflow Contributor Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Kubeflow Contributor Guide
+
+Welcome to the Kubeflow project! We'd love to accept your patches and 
+contributions to this project. Please read the 
+[contributor's guide in our docs](https://www.kubeflow.org/docs/about/contributing/).
+
+The contributor's guide:
+
+* Shows you where to find the Developer Certificate of Origin (DCO) that you need 
+  to agree to
+* Helps you get started with your first contribution to Kubeflow
+* Describes the pull request and review workflow in detail, including the
+  OWNERS files and automated workflow tool


### PR DESCRIPTION
Requirement ID: OSPS-GV-03.01

While active, the project documentation MUST include an explanation of the contribution process. Reason

Contribution guide not found in Security Insights data or via GitHub API

Recommendation
Create a CONTRIBUTING.md or CONTRIBUTING/ directory to outline the contribution process including the steps for submitting changes, and engaging with the project maintainers.

Provides guidelines for contributing to the Kubeflow project.