### PR TITLE
fix: Use top_k parameter instead of hardcoded value

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -167,7 +167,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, 15)
+            result = milvus_search(query, top_k)
             
             # Collect citations
             citations = []

--- a/server/app.py
+++ b/server/app.py
@@ -154,7 +154,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, 15)
+            result = milvus_search(query, top_k)
             
             # Collect citations
             citations = []


### PR DESCRIPTION
## Summary
Fixes the `execute_tool()` function to properly use the extracted `top_k` parameter instead of hardcoding it to 15.

## Changes
- Both `server/app.py` and `server-https/app.py` now respect the `top_k` value from tool arguments

## Impact
Users can control the number of search results via the `top_k` parameter (default: 5, range: 1-10).

-Fixes #19 