### PR TITLE
fix: Replace hardcoded namespace "santhosh" with generic configurable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Milvus is an open-source vector database designed for AI applications. It provid
 
 2. **Install Milvus**:
    ```bash
-   helm upgrade --install my-release zilliztech/milvus -n santhosh \
+   helm upgrade --install my-release zilliztech/milvus -n docs-agent \
      --set cluster.enabled=false \
      --set standalone.enabled=true \
      --set etcd.replicaCount=1 \
@@ -129,7 +129,7 @@ apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
   name: llm-runtime
-  namespace: santhosh
+  namespace: docs-agent
 spec:
   supportedModelFormats:
     - name: huggingface
@@ -158,7 +158,7 @@ apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   name: llama
-  namespace: santhosh
+  namespace: docs-agent
 spec:
   predictor:
     model:
@@ -289,13 +289,13 @@ For Kubeflow Pipelines to access Milvus, proper RBAC permissions are required:
 ```bash
 # Create role for Milvus access
 kubectl create role milvus-access \
-  --namespace santhosh \
+  --namespace docs-agent \
   --verb=get,list,watch \
   --resource=services,endpoints
 
 # Bind role to KFP service account
 kubectl create rolebinding kfp-to-milvus-editor \
-  --namespace santhosh \
+  --namespace docs-agent \
   --role=milvus-access \
   --serviceaccount=kubeflow:default-editor
 ```
@@ -663,10 +663,10 @@ Currently, the system uses browser local storage for chat history management to:
 
 ```bash
 # Check Milvus status
-kubectl get pods -n santhosh | grep milvus
+kubectl get pods -n docs-agent | grep milvus
 
 # Check KServe status
-kubectl get inferenceservice -n santhosh
+kubectl get inferenceservice -n docs-agent
 
 # Check API server logs
 kubectl logs -f deployment/docs-assistant-api

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Milvus is an open-source vector database designed for AI applications. It provid
 3. **Test Connection**:
    ```python
    from pymilvus import connections
-   connections.connect("default", host="my-release-milvus.santhosh.svc.cluster.local", port="19530")
+   connections.connect("default", host="my-release-milvus.docs-agent.svc.cluster.local", port="19530")
    print("Connected to Milvus successfully!")
    ```
 
@@ -203,7 +203,7 @@ spec:
 
 **Connection Details**:
 ```python
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.santhosh.svc.cluster.local/openai/v1/chat/completions")
+KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
 MODEL = os.getenv("MODEL", "llama3.1-8B")
 ```
 
@@ -551,7 +551,7 @@ if data.get('citations'):
 <tbody>
 <tr>
 <td><code>KSERVE_URL</code></td>
-<td><code>http://llama.santhosh.svc.cluster.local/openai/v1/chat/completions</code></td>
+<td><code>http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions</code></td>
 <td>KServe endpoint URL</td>
 </tr>
 <tr>
@@ -566,7 +566,7 @@ if data.get('citations'):
 </tr>
 <tr>
 <td><code>MILVUS_HOST</code></td>
-<td><code>my-release-milvus.santhosh.svc.cluster.local</code></td>
+<td><code>my-release-milvus.docs-agent.svc.cluster.local</code></td>
 <td>Milvus host</td>
 </tr>
 <tr>
@@ -627,6 +627,11 @@ if data.get('citations'):
 <td><code>base_url</code></td>
 <td><code>https://www.kubeflow.org/docs</code></td>
 <td>Base URL for citations</td>
+</tr>
+<tr>
+<td><code>milvus_host</code></td>
+<td><code>milvus-standalone-final.docs-agent.svc.cluster.local</code></td>
+<td>Milvus host (used by <code>kubeflow-pipeline.py</code> and <code>incremental-pipeline.py</code>)</td>
 </tr>
 </tbody>
 </table>
@@ -703,4 +708,3 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 - [Milvus](https://milvus.io/) for the vector database
 - [KServe](https://kserve.github.io/website/) for model serving
 - [vLLM](https://github.com/vllm-project/vllm) for high-performance LLM inference
-```

--- a/manifests/inference-service.yaml
+++ b/manifests/inference-service.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   name: llama
-  namespace: santhosh
+  namespace: docs-agent
 spec:
   predictor:
     model:

--- a/manifests/milvus-deployment.yaml
+++ b/manifests/milvus-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     app: milvus-standalone-final
     pod-template-hash: 5cb655b8d6
   name: milvus-standalone-final-5cb655b8d6-6ngrn
-  namespace: santhosh
+  namespace: docs-agent
   ownerReferences:
   - apiVersion: apps/v1
     blockOwnerDeletion: true

--- a/manifests/serving-runtime.yaml
+++ b/manifests/serving-runtime.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
   name: llm-runtime
-  namespace: santhosh
+  namespace: docs-agent
 spec:
   supportedModelFormats:
     - name: huggingface

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -87,7 +87,7 @@ python kubeflow-pipeline.py
 </tr>
 <tr>
 <td><code>milvus_host</code></td>
-<td>"milvus-standalone-final.santhosh.svc.cluster.local"</td>
+<td>"milvus-standalone-final.docs-agent.svc.cluster.local"</td>
 <td>Milvus server host</td>
 </tr>
 <tr>
@@ -209,7 +209,7 @@ kfp.compiler.Compiler().compile(
 </tr>
 <tr>
 <td><code>milvus_host</code></td>
-<td>"milvus-standalone-final.santhosh.svc.cluster.local"</td>
+<td>"milvus-standalone-final.docs-agent.svc.cluster.local"</td>
 <td>Milvus server host</td>
 </tr>
 <tr>

--- a/pipelines/github_rag_incremental_pipeline.yaml
+++ b/pipelines/github_rag_incremental_pipeline.yaml
@@ -8,7 +8,7 @@
 #    chunk_size: int [Default: 1200.0]
 #    collection_name: str [Default: 'docs_rag']
 #    github_token: str [Default: '']
-#    milvus_host: str [Default: 'milvus-standalone-final.santhosh.svc.cluster.local']
+#    milvus_host: str [Default: 'milvus-standalone-final.docs-agent.svc.cluster.local']
 #    milvus_port: str [Default: '19530']
 #    repo_name: str [Default: 'website']
 #    repo_owner: str [Default: 'kubeflow']
@@ -476,7 +476,7 @@ root:
         isOptional: true
         parameterType: STRING
       milvus_host:
-        defaultValue: milvus-standalone-final.santhosh.svc.cluster.local
+        defaultValue: milvus-standalone-final.docs-agent.svc.cluster.local
         isOptional: true
         parameterType: STRING
       milvus_port:

--- a/pipelines/github_rag_pipeline.yaml
+++ b/pipelines/github_rag_pipeline.yaml
@@ -8,7 +8,7 @@
 #    collection_name: str [Default: 'docs_rag']
 #    directory_path: str [Default: 'content/en']
 #    github_token: str [Default: '']
-#    milvus_host: str [Default: 'milvus-standalone-final.santhosh.svc.cluster.local']
+#    milvus_host: str [Default: 'milvus-standalone-final.docs-agent.svc.cluster.local']
 #    milvus_port: str [Default: '19530']
 #    repo_name: str [Default: 'website']
 #    repo_owner: str [Default: 'kubeflow']
@@ -374,7 +374,7 @@ root:
         isOptional: true
         parameterType: STRING
       milvus_host:
-        defaultValue: milvus-standalone-final.santhosh.svc.cluster.local
+        defaultValue: milvus-standalone-final.docs-agent.svc.cluster.local
         isOptional: true
         parameterType: STRING
       milvus_port:

--- a/pipelines/incremental-pipeline.py
+++ b/pipelines/incremental-pipeline.py
@@ -351,7 +351,7 @@ def github_rag_incremental_pipeline(
     base_url: str = "https://www.kubeflow.org/docs",
     chunk_size: int = 1200,
     chunk_overlap: int = 100,
-    milvus_host: str = "milvus-standalone-final.santhosh.svc.cluster.local",
+    milvus_host: str = "milvus-standalone-final.docs-agent.svc.cluster.local",
     milvus_port: str = "19530",
     collection_name: str = "docs_rag"
 ):

--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -255,7 +255,7 @@ def github_rag_pipeline(
     base_url: str = "https://www.kubeflow.org/docs",
     chunk_size: int = 1000,
     chunk_overlap: int = 100,
-    milvus_host: str = "milvus-standalone-final.santhosh.svc.cluster.local",
+    milvus_host: str = "milvus-standalone-final.docs-agent.svc.cluster.local",
     milvus_port: str = "19530",
     collection_name: str = "docs_rag"
 ):

--- a/server-https/app.py
+++ b/server-https/app.py
@@ -11,12 +11,12 @@ from sentence_transformers import SentenceTransformer
 from pymilvus import connections, Collection
 
 # Config
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.santhosh.svc.cluster.local/openai/v1/chat/completions")
+KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
 MODEL = os.getenv("MODEL", "llama3.1-8B")
 PORT = int(os.getenv("PORT", "8000"))
 
 # Milvus Config
-MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.santhosh.svc.cluster.local")
+MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local")
 MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
 MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
 MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")

--- a/server-https/virtualservice.yaml
+++ b/server-https/virtualservice.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: https-api-vs
-  namespace: santhosh
+  namespace: docs-agent
 spec:
   gateways:
   - kubeflow/kubeflow-gateway
@@ -16,7 +16,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: https-api.santhosh.svc.cluster.local
+        host: https-api.docs-agent.svc.cluster.local
         port:
           number: 80
     timeout: 0s

--- a/server/app.py
+++ b/server/app.py
@@ -11,12 +11,12 @@ from sentence_transformers import SentenceTransformer
 from pymilvus import connections, Collection
 
 # Config
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.santhosh.svc.cluster.local/openai/v1/chat/completions")
+KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
 MODEL = os.getenv("MODEL", "llama3.1-8B")
 PORT = int(os.getenv("PORT", "8000"))
 
 # Milvus Config
-MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.santhosh.svc.cluster.local")
+MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local")
 MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
 MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
 MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")

--- a/server/deployment.yaml
+++ b/server/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: ws-proxy
           image: santhoshtoorpu/ws-proxy:latest
-          imagePullPolicy: IfNotPresent   # actually reduce pulls
+          imagePullPolicy: IfNotPresent # actually reduce pulls
           resources:
             requests:
               cpu: "300m"
@@ -37,7 +37,7 @@ spec:
           env:
             # Match your app.py variable names
             - name: KSERVE_URL
-              value: "http://llama.santhosh.svc.cluster.local/openai/v1/chat/completions"
+              value: "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions"
             - name: MODEL
               value: "llama3.1-8B"
             - name: PORT


### PR DESCRIPTION
## Summary
Replaces hardcoded personal namespace `santhosh` with generic namespaces (`kubeflow` for KServe services, `docs-agent` for Milvus/app resources) to improve project portability.

## Changes
- Updated `server/app.py` and `server-https/app.py` default URLs
- Updated pipeline `milvus_host` parameters in `kubeflow-pipeline.py` and `incremental-pipeline.py`
- Updated all Kubernetes manifests and deployment configs
- Revised documentation examples in README files

Fixes #18
