### PR TITLE
fix(server): use top_k parameter in milvus_search

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -167,7 +167,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, 15)
+            result = milvus_search(query, top_k)
             
             # Collect citations
             citations = []

--- a/server/app.py
+++ b/server/app.py
@@ -154,7 +154,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, 15)
+            result = milvus_search(query, top_k)
             
             # Collect citations
             citations = []


### PR DESCRIPTION
**What does issue #19 means?**

The execute_tool() function retrieves the top_k parameter from user arguments but then instead of using the actual user request of top_k parameter it passes hardcode - 15 when milvus_search() is called. 

**What this PR does?**
Fixes the hardcoded 15 value to top_k parameter when milvus_search() is called.

- server/app.py (line 157)
- server-https/app.py (line 170)

**Why this is needed?**
User requests can be of any parameter not just 15.
Users expect: if they pass top_k=3, they should get 3 results instead of the hardcode - 15

**DCO Checklist**

- [x] I have read the [Kubeflow Contributing Guide](https://www.kubeflow.org/docs/about/contributing/)
- [x] I have signed off my commits using git commit -s
- [x] My PR title follows the convention: fix(server): use top_k parameter in milvus_search