### PR TITLE
Fix: Honor top_k parameter in tool execution for Milvus search

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -167,7 +167,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, 15)
+            result = milvus_search(query, min(top_k, 10))
             
             # Collect citations
             citations = []

--- a/server/app.py
+++ b/server/app.py
@@ -154,7 +154,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, 15)
+            result = milvus_search(query, min(top_k, 10))
             
             # Collect citations
             citations = []


### PR DESCRIPTION
  ## Summary

  Both `server/app.py` and `server-https/app.py` define a `top_k` tool parameter  (with a schema maximum of 10), parse it from the tool call arguments, and log it   but then pass a hardcoded value of `15` to `milvus_search()`, ignoring the user's
  requested `top_k` entirely.

  This PR replaces the hardcoded `15` with `min(top_k, 10)` so the parameter is  actually honored while still respecting the schema-defined maximum.

  ## Changes

  - `server/app.py` — use `min(top_k, 10)` instead of `15` in `execute_tool()`
  - `server-https/app.py` — same fix

  ## Test plan

  - [x] Verify both files compile cleanly (`python -m py_compile server/app.py server-https/app.py`)
  - [x] Confirm `milvus_search` is called with the correct `top_k` value via log output
  - [x] Confirm no hardcoded `15` remains in `execute_tool()` across either server