### PR TITLE
feat(server): Implement Milvus connection pooling (Fixes #28)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -66,10 +66,9 @@ Style
 
 
 def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
-    """Execute a semantic search in Milvus and return structured JSON serializable results."""
+    """Execute a semantic search in Milvus using the persistent 'default' connection."""
     try:
-        # Connect to Milvus
-        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
+        # Re-use existing 'default' connection
         collection = Collection(MILVUS_COLLECTION)
         collection.load()
 
@@ -104,11 +103,6 @@ def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
     except Exception as e:
         print(f"[ERROR] Milvus search failed: {e}")
         return {"results": []}
-    finally:
-        try:
-            connections.disconnect(alias="default")
-        except Exception:
-            pass
 TOOLS = [
     {
         "type": "function",
@@ -430,6 +424,13 @@ async def main():
     print(f"   LLM Service: {KSERVE_URL}")
     print(f"   Milvus: {MILVUS_HOST}:{MILVUS_PORT}")
     print(f"   Collection: {MILVUS_COLLECTION}")
+    
+    # Establish persistent Milvus connection
+    print(f"[INFO] Establishing persistent connection to Milvus at {MILVUS_HOST}:{MILVUS_PORT}")
+    try:
+        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
+    except Exception as e:
+        print(f"[ERROR] Failed to establish persistent Milvus connection: {e}")
     
     # Configure logging
     logging.getLogger("websockets").setLevel(logging.WARNING)


### PR DESCRIPTION
This PR implements Milvus connection pooling as requested in #28, significantly reducing latency and resource overhead in the docs-agent backend.

### Changes
*   **Persistent Connections:** Established a single persistent connection to Milvus at server startup instead of a new connection per-request.
*   **FastAPI Lifespan:** Utilized the `lifespan` context manager in `server-https/app.py` for clean startup/shutdown.
*   **Startup Logic:** Moved connection initialization to the `main()` loop in `server/app.py`.
*   **Search Refactoring:** Updated `milvus_search()` to reuse the existing `default` connection alias and removed redundant disconnect calls.

### Performance Impact
For agentic workflows (like the LangGraph router) that perform 2-5 searches per user turn, this removes the connection overhead from every search, resulting in a noticeably faster response time and less load on the Milvus server.

Linked Issue: #28