### PR TITLE
fix(server): Correct typo in system prompts (Fixes #17)

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -27,7 +27,7 @@ SYSTEM_PROMPT = """
 You are the Kubeflow Docs Assistant.
 
 !!IMPORTANT!!
-- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documenation specific and relevant.
+- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
 - You should never output the raw tool call to the user.
 
 Your role
@@ -49,7 +49,7 @@ Tool Use
   - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
   - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
 
-The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documenation specific and relevant.
+The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
 
 Routing
 - Greetings/small talk → respond briefly, no tool.  

--- a/server/app.py
+++ b/server/app.py
@@ -27,7 +27,7 @@ SYSTEM_PROMPT = """
 You are the Kubeflow Docs Assistant.
 
 !!IMPORTANT!!
-- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documenation specific and relevant.
+- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
 - You should never output the raw tool call to the user.
 
 Your role
@@ -49,7 +49,7 @@ Tool Use
   - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
   - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
 
-The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documenation specific and relevant.
+The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
 
 Routing
 - Greetings/small talk → respond briefly, no tool.  


### PR DESCRIPTION
This PR fixes a small typo ('documenation' -> 'documentation') in the system prompt in both `server/app.py` and `server-https/app.py`.

Fixes #17