### PR TITLE
feat(eval): add retrieval evaluation framework with golden dataset

### DIFF
--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,0 +1,5 @@
+"""Retrieval evaluation framework for the Kubeflow docs-agent.
+
+This package provides tools for measuring retrieval quality using a
+curated golden dataset of test queries with expected relevant documents.
+"""

--- a/eval/evaluate.py
+++ b/eval/evaluate.py
@@ -1,0 +1,300 @@
+"""Retrieval quality evaluation for the Kubeflow docs-agent.
+
+This script loads the golden dataset, runs each query through the
+retrieval pipeline, and computes standard IR metrics:
+
+- **Recall@k**: Fraction of expected sources found in the top-k results.
+- **Precision@k**: Fraction of top-k results that match an expected source.
+- **MRR (Mean Reciprocal Rank)**: Average of 1/rank for the first
+  relevant result across all queries.
+
+Usage::
+
+    # Against a live Milvus instance:
+    python -m eval.evaluate
+
+    # With custom settings:
+    python -m eval.evaluate --top-k 10 --dataset eval/golden_dataset.json
+
+    # Dry-run (intent classification only, no Milvus required):
+    python -m eval.evaluate --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Ensure project root is importable
+_project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def recall_at_k(
+    retrieved_sources: List[str],
+    expected_patterns: List[str],
+    k: int,
+) -> float:
+    """Compute recall@k — fraction of expected patterns found in top-k results.
+
+    A retrieved source is considered relevant if any of the expected
+    patterns appears as a substring (case-insensitive).
+    """
+    if not expected_patterns:
+        return 1.0  # No expectations → trivially satisfied
+
+    top_k = retrieved_sources[:k]
+    found = 0
+    for pattern in expected_patterns:
+        pattern_lower = pattern.lower()
+        if any(pattern_lower in src.lower() for src in top_k):
+            found += 1
+    return found / len(expected_patterns)
+
+
+def precision_at_k(
+    retrieved_sources: List[str],
+    expected_patterns: List[str],
+    k: int,
+) -> float:
+    """Compute precision@k — fraction of top-k results that are relevant."""
+    if not expected_patterns:
+        return 1.0
+
+    top_k = retrieved_sources[:k]
+    if not top_k:
+        return 0.0
+
+    relevant = 0
+    for src in top_k:
+        src_lower = src.lower()
+        if any(pat.lower() in src_lower for pat in expected_patterns):
+            relevant += 1
+    return relevant / len(top_k)
+
+
+def reciprocal_rank(
+    retrieved_sources: List[str],
+    expected_patterns: List[str],
+) -> float:
+    """Compute the reciprocal rank of the first relevant result."""
+    if not expected_patterns:
+        return 1.0
+
+    for rank, src in enumerate(retrieved_sources, 1):
+        src_lower = src.lower()
+        if any(pat.lower() in src_lower for pat in expected_patterns):
+            return 1.0 / rank
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Evaluation runner
+# ---------------------------------------------------------------------------
+
+
+def load_golden_dataset(path: str) -> List[Dict[str, Any]]:
+    """Load the golden dataset from a JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data["queries"]
+
+
+def evaluate_retrieval(
+    queries: List[Dict[str, Any]],
+    top_k: int = 5,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Run evaluation across all queries and compute aggregate metrics.
+
+    Parameters
+    ----------
+    queries
+        List of golden dataset entries.
+    top_k
+        Number of results to retrieve per query.
+    dry_run
+        If True, only evaluate intent classification (no Milvus needed).
+
+    Returns
+    -------
+    dict
+        Aggregate and per-query metrics.
+    """
+    # Lazy imports — only needed when actually running retrieval
+    if not dry_run:
+        from shared.rag_core import milvus_search
+    from agent.router import classify
+
+    per_query: List[Dict[str, Any]] = []
+    total_recall = 0.0
+    total_precision = 0.0
+    total_rr = 0.0
+    intent_correct = 0
+    retrieval_queries = 0
+
+    for entry in queries:
+        query_id = entry["id"]
+        query = entry["query"]
+        expected_intent = entry["intent"]
+        expected_sources = entry.get("expected_sources", [])
+
+        # -- Intent classification --
+        state = {"query": query}
+        classified = classify(state)
+        predicted_intent = classified["intent"]
+        intent_match = predicted_intent == expected_intent
+        if intent_match:
+            intent_correct += 1
+
+        result_entry: Dict[str, Any] = {
+            "id": query_id,
+            "query": query,
+            "expected_intent": expected_intent,
+            "predicted_intent": predicted_intent,
+            "intent_correct": intent_match,
+        }
+
+        # -- Retrieval evaluation (skip for general/dry-run) --
+        if not dry_run and expected_intent != "general":
+            retrieval_queries += 1
+            search_result = milvus_search(query, top_k=top_k)
+            hits = search_result.get("results", [])
+
+            # Extract source identifiers (file_path + citation_url)
+            retrieved_sources = []
+            for hit in hits:
+                fp = hit.get("file_path", "")
+                url = hit.get("citation_url", "")
+                retrieved_sources.append(f"{fp} {url}")
+
+            r_at_k = recall_at_k(retrieved_sources, expected_sources, top_k)
+            p_at_k = precision_at_k(retrieved_sources, expected_sources, top_k)
+            rr = reciprocal_rank(retrieved_sources, expected_sources)
+
+            total_recall += r_at_k
+            total_precision += p_at_k
+            total_rr += rr
+
+            result_entry.update(
+                {
+                    "recall_at_k": round(r_at_k, 4),
+                    "precision_at_k": round(p_at_k, 4),
+                    "reciprocal_rank": round(rr, 4),
+                    "num_hits": len(hits),
+                    "top_sources": [h.get("file_path", "") for h in hits[:3]],
+                }
+            )
+
+        per_query.append(result_entry)
+
+    # -- Aggregate metrics --
+    n = len(queries)
+    aggregate: Dict[str, Any] = {
+        "total_queries": n,
+        "intent_accuracy": round(intent_correct / n, 4) if n else 0,
+    }
+
+    if retrieval_queries > 0:
+        aggregate.update(
+            {
+                "retrieval_queries": retrieval_queries,
+                "mean_recall_at_k": round(total_recall / retrieval_queries, 4),
+                "mean_precision_at_k": round(total_precision / retrieval_queries, 4),
+                "mrr": round(total_rr / retrieval_queries, 4),
+            }
+        )
+
+    return {"aggregate": aggregate, "per_query": per_query}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate docs-agent retrieval quality against a golden dataset."
+    )
+    parser.add_argument(
+        "--dataset",
+        default=str(Path(__file__).parent / "golden_dataset.json"),
+        help="Path to the golden dataset JSON file.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=5,
+        help="Number of results to retrieve per query (default: 5).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only evaluate intent classification (no Milvus needed).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Write full results to this JSON file.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    logger.info("Loading golden dataset from %s", args.dataset)
+    queries = load_golden_dataset(args.dataset)
+    logger.info("Loaded %d queries", len(queries))
+
+    if args.dry_run:
+        logger.info("Dry-run mode: only evaluating intent classification")
+
+    results = evaluate_retrieval(queries, top_k=args.top_k, dry_run=args.dry_run)
+
+    # Print summary
+    agg = results["aggregate"]
+    print("\n" + "=" * 60)
+    print("EVALUATION RESULTS")
+    print("=" * 60)
+    print(f"  Total queries:        {agg['total_queries']}")
+    print(f"  Intent accuracy:      {agg['intent_accuracy']:.1%}")
+
+    if "mrr" in agg:
+        print(f"  Retrieval queries:    {agg['retrieval_queries']}")
+        print(f"  Mean Recall@{args.top_k}:       {agg['mean_recall_at_k']:.4f}")
+        print(f"  Mean Precision@{args.top_k}:    {agg['mean_precision_at_k']:.4f}")
+        print(f"  MRR:                  {agg['mrr']:.4f}")
+
+    print("=" * 60)
+
+    # Show per-query intent mismatches
+    mismatches = [q for q in results["per_query"] if not q["intent_correct"]]
+    if mismatches:
+        print(f"\nIntent mismatches ({len(mismatches)}):")
+        for m in mismatches:
+            print(
+                f"  [{m['id']}] {m['query']!r} "
+                f"— expected={m['expected_intent']}, got={m['predicted_intent']}"
+            )
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2, ensure_ascii=False)
+        print(f"\nFull results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/evaluate.py
+++ b/eval/evaluate.py
@@ -39,6 +39,47 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Lightweight intent classifier (for evaluation only)
+# ---------------------------------------------------------------------------
+
+#: In production the Kagent Agent CRD's system prompt routes queries to
+#: the right MCP tool via the LLM.  For *offline* evaluation we use a
+#: simple keyword classifier so the eval framework has no dependency on
+#: the agent package or any specific orchestration framework.
+
+_PLATFORM_KEYWORDS = [
+    "terraform", "oci", "oke", "oracle", "deploy", "deployment",
+    "infrastructure", "cluster", "helm", "istio", "knative",
+    "cert-manager", "dex", "oidc", "ingress", "gpu", "node pool",
+    "autoscal", "kustomize", "argocd", "gitops",
+]
+
+_KUBEFLOW_KEYWORDS = [
+    "kubeflow", "kfp", "pipeline", "pipelines", "kserve",
+    "inferenceservice", "katib", "notebook", "jupyter", "sdk",
+    "training", "tfjob", "pytorchjob", "mpijob", "experiment",
+    "trial", "profile", "manifest",
+]
+
+
+def classify_intent(query: str) -> str:
+    """Classify user intent via keyword matching.
+
+    Returns one of ``"kubeflow_docs"``, ``"platform_arch"``, or
+    ``"general"``.  Platform keywords are checked first because they
+    are more specific.
+    """
+    query_lower = query.lower()
+    for kw in _PLATFORM_KEYWORDS:
+        if kw in query_lower:
+            return "platform_arch"
+    for kw in _KUBEFLOW_KEYWORDS:
+        if kw in query_lower:
+            return "kubeflow_docs"
+    return "general"
+
+
+# ---------------------------------------------------------------------------
 # Metrics
 # ---------------------------------------------------------------------------
 
@@ -134,18 +175,10 @@ def evaluate_retrieval(
     dict
         Aggregate and per-query metrics.
     """
-    # Lazy imports — only needed when actually running retrieval
+    # Lazy import — only needed when actually running retrieval
+    milvus_search = None
     if not dry_run:
         from shared.rag_core import milvus_search
-
-    try:
-        from agent.router import classify
-    except ImportError:
-        logger.warning(
-            "agent.router is not available (missing langgraph?). "
-            "Intent classification will be skipped."
-        )
-        classify = None  # type: ignore[assignment]
 
     per_query: List[Dict[str, Any]] = []
     total_recall = 0.0
@@ -160,13 +193,8 @@ def evaluate_retrieval(
         expected_intent = entry["intent"]
         expected_sources = entry.get("expected_sources", [])
 
-        # -- Intent classification --
-        if classify is not None:
-            state = {"query": query}
-            classified = classify(state)
-            predicted_intent = classified["intent"]
-        else:
-            predicted_intent = "unknown"
+        # -- Intent classification (self-contained, no agent dependency) --
+        predicted_intent = classify_intent(query)
         intent_match = predicted_intent == expected_intent
         if intent_match:
             intent_correct += 1
@@ -181,6 +209,7 @@ def evaluate_retrieval(
 
         # -- Retrieval evaluation (skip for general/dry-run) --
         if not dry_run and expected_intent != "general":
+            assert milvus_search is not None  # guaranteed by `not dry_run`
             retrieval_queries += 1
             search_result = milvus_search(query, top_k=top_k)
             hits = search_result.get("results", [])

--- a/eval/golden_dataset.json
+++ b/eval/golden_dataset.json
@@ -1,0 +1,251 @@
+{
+  "description": "Golden dataset for evaluating Kubeflow docs-agent retrieval quality. Each entry specifies a user query, the expected intent category, and a set of expected relevant document paths or URL patterns that a good retrieval system should surface.",
+  "version": "1.0.0",
+  "queries": [
+    {
+      "id": "kfp-001",
+      "query": "How do I create a Kubeflow pipeline?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["pipelines", "pipeline"],
+      "tags": ["pipelines", "getting-started"]
+    },
+    {
+      "id": "kfp-002",
+      "query": "What is the Kubeflow Pipelines SDK?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["sdk", "pipelines"],
+      "tags": ["pipelines", "sdk"]
+    },
+    {
+      "id": "kfp-003",
+      "query": "How to disable caching in KFP v2",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["cache", "pipelines"],
+      "tags": ["pipelines", "caching"]
+    },
+    {
+      "id": "kfp-004",
+      "query": "How do I pass data between pipeline components?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["pipelines", "component"],
+      "tags": ["pipelines", "data-passing"]
+    },
+    {
+      "id": "kfp-005",
+      "query": "What are lightweight Python components in KFP?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["pipelines", "component", "lightweight"],
+      "tags": ["pipelines", "components"]
+    },
+    {
+      "id": "kserve-001",
+      "query": "How to deploy a model with KServe InferenceService?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["kserve", "inference"],
+      "tags": ["kserve", "deployment"]
+    },
+    {
+      "id": "kserve-002",
+      "query": "KServe canary rollout configuration",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["kserve", "canary"],
+      "tags": ["kserve", "canary"]
+    },
+    {
+      "id": "kserve-003",
+      "query": "How does KServe scale to zero work?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["kserve", "scale", "autoscal"],
+      "tags": ["kserve", "autoscaling"]
+    },
+    {
+      "id": "kserve-004",
+      "query": "How to serve a transformer with KServe",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["kserve", "transformer"],
+      "tags": ["kserve", "transformer"]
+    },
+    {
+      "id": "katib-001",
+      "query": "How does Katib hyperparameter tuning work?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["katib", "hyperparameter"],
+      "tags": ["katib", "tuning"]
+    },
+    {
+      "id": "katib-002",
+      "query": "What algorithms does Katib support?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["katib", "algorithm"],
+      "tags": ["katib", "algorithms"]
+    },
+    {
+      "id": "katib-003",
+      "query": "Create a Katib experiment with random search",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["katib", "experiment", "random"],
+      "tags": ["katib", "experiment"]
+    },
+    {
+      "id": "nb-001",
+      "query": "How to create a Jupyter notebook server in Kubeflow?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["notebook", "jupyter"],
+      "tags": ["notebooks", "getting-started"]
+    },
+    {
+      "id": "nb-002",
+      "query": "Configure GPU for Kubeflow notebooks",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["notebook", "gpu"],
+      "tags": ["notebooks", "gpu"]
+    },
+    {
+      "id": "train-001",
+      "query": "How to run distributed PyTorch training on Kubeflow?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["training", "pytorch", "pytorchjob"],
+      "tags": ["training", "pytorch"]
+    },
+    {
+      "id": "train-002",
+      "query": "TFJob distributed training configuration",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["training", "tfjob", "tensorflow"],
+      "tags": ["training", "tensorflow"]
+    },
+    {
+      "id": "train-003",
+      "query": "How to use the Kubeflow Training Operator?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["training", "operator"],
+      "tags": ["training", "operator"]
+    },
+    {
+      "id": "install-001",
+      "query": "How to install Kubeflow on a local machine?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["install", "local", "started"],
+      "tags": ["installation", "local"]
+    },
+    {
+      "id": "install-002",
+      "query": "Kubeflow installation on AWS EKS",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["install", "aws", "eks"],
+      "tags": ["installation", "aws"]
+    },
+    {
+      "id": "install-003",
+      "query": "Install Kubeflow on GKE",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["install", "gke", "google"],
+      "tags": ["installation", "gke"]
+    },
+    {
+      "id": "profile-001",
+      "query": "How do Kubeflow profiles and multi-tenancy work?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["profile", "multi-tenant"],
+      "tags": ["profiles", "multi-tenancy"]
+    },
+    {
+      "id": "profile-002",
+      "query": "How to manage user permissions in Kubeflow?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["profile", "permission", "rbac"],
+      "tags": ["profiles", "rbac"]
+    },
+    {
+      "id": "plat-001",
+      "query": "How to deploy Kubeflow with Terraform?",
+      "intent": "platform_arch",
+      "expected_sources": ["terraform", "deploy"],
+      "tags": ["platform", "terraform"]
+    },
+    {
+      "id": "plat-002",
+      "query": "Kubeflow deployment on Oracle Cloud OKE",
+      "intent": "platform_arch",
+      "expected_sources": ["oci", "oke", "oracle"],
+      "tags": ["platform", "oci"]
+    },
+    {
+      "id": "plat-003",
+      "query": "How does Istio work with Kubeflow?",
+      "intent": "platform_arch",
+      "expected_sources": ["istio", "ingress"],
+      "tags": ["platform", "istio"]
+    },
+    {
+      "id": "plat-004",
+      "query": "Configure Dex authentication for Kubeflow",
+      "intent": "platform_arch",
+      "expected_sources": ["dex", "oidc", "auth"],
+      "tags": ["platform", "auth"]
+    },
+    {
+      "id": "plat-005",
+      "query": "Kustomize overlays for Kubeflow manifests",
+      "intent": "platform_arch",
+      "expected_sources": ["kustomize", "manifest"],
+      "tags": ["platform", "kustomize"]
+    },
+    {
+      "id": "plat-006",
+      "query": "How to set up a GPU node pool for Kubeflow",
+      "intent": "platform_arch",
+      "expected_sources": ["gpu", "node pool", "cluster"],
+      "tags": ["platform", "gpu"]
+    },
+    {
+      "id": "plat-007",
+      "query": "Kubeflow Helm chart installation",
+      "intent": "platform_arch",
+      "expected_sources": ["helm", "deploy"],
+      "tags": ["platform", "helm"]
+    },
+    {
+      "id": "gen-001",
+      "query": "Hello, how are you?",
+      "intent": "general",
+      "expected_sources": [],
+      "tags": ["general", "greeting"]
+    },
+    {
+      "id": "gen-002",
+      "query": "What is Kubernetes?",
+      "intent": "general",
+      "expected_sources": [],
+      "tags": ["general", "k8s"]
+    },
+    {
+      "id": "gen-003",
+      "query": "Explain what machine learning is",
+      "intent": "general",
+      "expected_sources": [],
+      "tags": ["general", "ml"]
+    },
+    {
+      "id": "gen-004",
+      "query": "Who won the Super Bowl?",
+      "intent": "general",
+      "expected_sources": [],
+      "tags": ["general", "out-of-scope"]
+    },
+    {
+      "id": "gen-005",
+      "query": "What is a Docker container?",
+      "intent": "general",
+      "expected_sources": [],
+      "tags": ["general", "docker"]
+    },
+    {
+      "id": "misc-001",
+      "query": "What version of Kubeflow is the latest?",
+      "intent": "kubeflow_docs",
+      "expected_sources": ["version", "release"],
+      "tags": ["misc", "version"]
+    }
+  ]
+}

--- a/server-https/Dockerfile
+++ b/server-https/Dockerfile
@@ -15,6 +15,7 @@ ENV PORT=8000
 USER appuser
 
 # App
+COPY shared/ /app/shared/
 COPY app.py /app/
 
 EXPOSE 8000

--- a/server-https/app.py
+++ b/server-https/app.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 import os
+from typing import Dict, Any, List, AsyncGenerator
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -10,22 +11,42 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
 
-# Add project root to path so shared module is importable
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from shared.rag_core import (  # noqa: E402
-    KSERVE_URL,
-    MODEL,
-    MILVUS_HOST,
-    MILVUS_PORT,
-    MILVUS_COLLECTION,
-    PORT,
-    execute_tool,
-    deduplicate_citations,
-    build_chat_payload,
-)
-
-from typing import Dict, Any, List, AsyncGenerator
+# Import shared module, supporting both installed-package and repo layouts
+try:
+    from shared.rag_core import (
+        KSERVE_URL,
+        MODEL,
+        MILVUS_HOST,
+        MILVUS_PORT,
+        MILVUS_COLLECTION,
+        PORT,
+        execute_tool,
+        deduplicate_citations,
+        build_chat_payload,
+    )
+except ModuleNotFoundError as _original_exc:
+    # Fallback for development: add project root so ../shared is importable
+    _project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if _project_root not in sys.path:
+        sys.path.insert(0, _project_root)
+    try:
+        from shared.rag_core import (
+            KSERVE_URL,
+            MODEL,
+            MILVUS_HOST,
+            MILVUS_PORT,
+            MILVUS_COLLECTION,
+            PORT,
+            execute_tool,
+            deduplicate_citations,
+            build_chat_payload,
+        )
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "Could not import 'shared.rag_core'. Ensure the 'shared/' directory "
+            "is available on PYTHONPATH or copied into the runtime environment "
+            "(for Docker, include 'COPY shared/ /app/shared/')."
+        ) from _original_exc
 
 logger = logging.getLogger(__name__)
 

--- a/server-https/app.py
+++ b/server-https/app.py
@@ -1,100 +1,33 @@
-import os
 import json
+import logging
+import sys
+import os
+
 import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
-from typing import Dict, Any, List, Optional, AsyncGenerator
-from sentence_transformers import SentenceTransformer
-from pymilvus import connections, Collection
 
-# Config
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
-MODEL = os.getenv("MODEL", "llama3.1-8B")
-PORT = int(os.getenv("PORT", "8000"))
+# Add project root to path so shared module is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-# Milvus Config
-MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local")
-MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
-MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
-MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
+from shared.rag_core import (  # noqa: E402
+    KSERVE_URL,
+    MODEL,
+    MILVUS_HOST,
+    MILVUS_PORT,
+    MILVUS_COLLECTION,
+    PORT,
+    execute_tool,
+    deduplicate_citations,
+    build_chat_payload,
+)
 
-# System prompt (same as WebSocket version)
-SYSTEM_PROMPT = """
-You are the Kubeflow Docs Assistant.
+from typing import Dict, Any, List, AsyncGenerator
 
-!!IMPORTANT!!
-- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
-- You should never output the raw tool call to the user.
-
-Your role
-- Always answer the user's question directly.
-- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
-- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
-
-Tool Use
-- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
-- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
-- When you do call the tool:
-  • Use one clear, focused query.  
-  • Summarize the result in your own words.  
-  • If no results are relevant, say "not found in the docs" and suggest refining the query.
-- Example usage:
-  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
-  - You should make a tool call to search the docs with a query "kubeflow setup".
-
-  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
-  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
-
-The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
-
-Routing
-- Greetings/small talk → respond briefly, no tool.  
-- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
-- Kubeflow-specific → answer and call the tool if documentation is needed.  
-
-Style
-- Be concise (2–5 sentences). Use bullet points or steps when helpful.
-- Provide examples only when asked.
-- Never invent features. If unsure, say so.
-- Reply in clean Markdown.
-"""
-
-TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "search_kubeflow_docs",
-            "description": (
-                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
-                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
-                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
-                        "minLength": 1
-                    },
-                    "top_k": {
-                        "type": "integer",
-                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
-                        "default": 5,
-                        "minimum": 1,
-                        "maximum": 10
-                    }
-                },
-                "required": ["query"],
-                "additionalProperties": False
-            }
-        }
-    }
-]
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Kubeflow Docs API Service", version="1.0.0")
 
@@ -107,252 +40,197 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 class ChatRequest(BaseModel):
     message: str
-    stream: Optional[bool] = True
+    stream: bool = True
 
-def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
-    """Execute a semantic search in Milvus and return structured JSON serializable results."""
-    try:
-        # Connect to Milvus
-        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
-        collection = Collection(MILVUS_COLLECTION)
-        collection.load()
 
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
-
-        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
-        results = collection.search(
-            data=[query_vec],
-            anns_field=MILVUS_VECTOR_FIELD,
-            param=search_params,
-            limit=int(top_k),
-            output_fields=["file_path", "content_text", "citation_url"],
-        )
-
-        hits = []
-        for hit in results[0]:
-            # similarity = 1 - distance for COSINE in Milvus
-            similarity = 1.0 - float(hit.distance)
-            entity = hit.entity
-            content_text = entity.get("content_text") or ""
-            if isinstance(content_text, str) and len(content_text) > 400:
-                content_text = content_text[:400] + "..."
-            hits.append({
-                "similarity": similarity,
-                "file_path": entity.get("file_path"),
-                "citation_url": entity.get("citation_url"),
-                "content_text": content_text,
-            })
-        return {"results": hits}
-    except Exception as e:
-        print(f"[ERROR] Milvus search failed: {e}")
-        return {"results": []}
-    finally:
-        try:
-            connections.disconnect(alias="default")
-        except Exception:
-            pass
-
-async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
-    """Execute a tool call and return the result and citations"""
-    try:
-        function_name = tool_call.get("function", {}).get("name")
-        arguments = json.loads(tool_call.get("function", {}).get("arguments", "{}"))
-        
-        if function_name == "search_kubeflow_docs":
-            query = arguments.get("query", "")
-            top_k = arguments.get("top_k", 5)
-            
-            print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, top_k)
-            
-            # Collect citations
-            citations = []
-            formatted_results = []
-            
-            for hit in result.get("results", []):
-                citation_url = hit.get('citation_url', '')
-                if citation_url and citation_url not in citations:
-                    citations.append(citation_url)
-                
-                formatted_results.append(
-                    f"File: {hit.get('file_path', 'Unknown')}\n"
-                    f"Content: {hit.get('content_text', '')}\n"
-                    f"URL: {citation_url}\n"
-                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
-                )
-            
-            formatted_text = "\n".join(formatted_results) if formatted_results else "No relevant results found."
-            return formatted_text, citations
-        
-        return f"Unknown tool: {function_name}", []
-        
-    except Exception as e:
-        print(f"[ERROR] Tool execution failed: {e}")
-        return f"Tool execution failed: {e}", []
-
-async def stream_llm_response(payload: Dict[str, Any]) -> AsyncGenerator[str, None]:
+async def stream_llm_response(
+    payload: Dict[str, Any],
+) -> AsyncGenerator[str, None]:
     """Stream response from LLM and handle tool calls, yielding SSE events"""
-    citations_collector = []
-    
+    citations_collector: List[str] = []
+
     try:
         async with httpx.AsyncClient(timeout=120) as client:
             async with client.stream("POST", KSERVE_URL, json=payload) as response:
                 if response.status_code != 200:
                     error_msg = f"LLM service error: HTTP {response.status_code}"
-                    print(f"[ERROR] {error_msg}")
+                    logger.error(error_msg)
                     yield f"data: {json.dumps({'type': 'error', 'content': error_msg})}\n\n"
                     return
-                
+
                 # Buffer for accumulating tool calls
                 tool_calls_buffer = {}
-                
+
                 async for line in response.aiter_lines():
                     if not line.startswith("data: "):
                         continue
-                    
+
                     data = line[6:]  # Remove "data: " prefix
                     if data == "[DONE]":
                         break
-                    
+
                     try:
                         chunk = json.loads(data)
                         choices = chunk.get("choices", [])
                         if not choices:
                             continue
-                            
+
                         delta = choices[0].get("delta", {})
                         finish_reason = choices[0].get("finish_reason")
-                        
+
                         # Handle tool calls in streaming
                         if "tool_calls" in delta:
                             tool_calls = delta["tool_calls"]
                             for tool_call in tool_calls:
                                 index = tool_call.get("index", 0)
-                                
+
                                 # Initialize tool call buffer if needed
                                 if index not in tool_calls_buffer:
                                     tool_calls_buffer[index] = {
                                         "id": tool_call.get("id", ""),
                                         "type": tool_call.get("type", "function"),
                                         "function": {
-                                            "name": tool_call.get("function", {}).get("name", ""),
-                                            "arguments": ""
-                                        }
+                                            "name": tool_call.get("function", {}).get(
+                                                "name", ""
+                                            ),
+                                            "arguments": "",
+                                        },
                                     }
-                                
+
                                 # Update tool call data
                                 if tool_call.get("id"):
                                     tool_calls_buffer[index]["id"] = tool_call["id"]
                                 if tool_call.get("type"):
                                     tool_calls_buffer[index]["type"] = tool_call["type"]
-                                
+
                                 function_data = tool_call.get("function", {})
                                 if function_data.get("name"):
-                                    tool_calls_buffer[index]["function"]["name"] = function_data["name"]
+                                    tool_calls_buffer[index]["function"]["name"] = (
+                                        function_data["name"]
+                                    )
                                 if "arguments" in function_data:
-                                    tool_calls_buffer[index]["function"]["arguments"] += function_data["arguments"]
-                        
+                                    tool_calls_buffer[index]["function"][
+                                        "arguments"
+                                    ] += function_data["arguments"]
+
                         # Handle regular content
                         elif "content" in delta and delta["content"]:
                             yield f"data: {json.dumps({'type': 'content', 'content': delta['content']})}\n\n"
-                        
+
                         # Handle finish reason - execute tools if needed
                         if finish_reason == "tool_calls":
-                            print(f"[TOOL] Finish reason: tool_calls, executing {len(tool_calls_buffer)} tools")
-                            
+                            logger.info(
+                                "Finish reason: tool_calls, executing %d tools",
+                                len(tool_calls_buffer),
+                            )
+
                             # Execute all accumulated tool calls
                             for tool_call in tool_calls_buffer.values():
-                                if tool_call["function"]["name"] and tool_call["function"]["arguments"]:
+                                if (
+                                    tool_call["function"]["name"]
+                                    and tool_call["function"]["arguments"]
+                                ):
                                     try:
-                                        print(f"[TOOL] Executing: {tool_call['function']['name']}")
-                                        print(f"[TOOL] Arguments: {tool_call['function']['arguments']}")
-                                        
-                                        result, tool_citations = await execute_tool(tool_call)
-                                        
+                                        logger.info(
+                                            "Executing: %s",
+                                            tool_call["function"]["name"],
+                                        )
+
+                                        result, tool_citations = await execute_tool(
+                                            tool_call
+                                        )
+
                                         # Collect citations
                                         citations_collector.extend(tool_citations)
-                                        
+
                                         # Send tool execution result
                                         yield f"data: {json.dumps({'type': 'tool_result', 'tool_name': tool_call['function']['name'], 'content': result})}\n\n"
-                                        
+
                                         # Make follow-up request with tool results
-                                        async for follow_up_chunk in handle_tool_follow_up(payload, tool_call, result, citations_collector):
+                                        async for follow_up_chunk in handle_tool_follow_up(
+                                            payload,
+                                            tool_call,
+                                            result,
+                                            citations_collector,
+                                        ):
                                             yield follow_up_chunk
-                                        
+
                                     except Exception as e:
-                                        print(f"[ERROR] Tool execution error: {e}")
+                                        logger.error("Tool execution error: %s", e)
                                         yield f"data: {json.dumps({'type': 'error', 'content': f'Tool execution failed: {e}'})}\n\n"
-                            
+
                             tool_calls_buffer.clear()
                             break  # Tool execution complete, exit streaming loop
-                            
+
                     except json.JSONDecodeError as e:
-                        print(f"[ERROR] JSON decode error: {e}, line: {line}")
+                        logger.error("JSON decode error: %s, line: %s", e, line)
                         continue
-        
+
         # Send citations if any were collected
         if citations_collector:
-            # Remove duplicates while preserving order
-            unique_citations = []
-            for citation in citations_collector:
-                if citation not in unique_citations:
-                    unique_citations.append(citation)
-            
+            unique_citations = deduplicate_citations(citations_collector)
             yield f"data: {json.dumps({'type': 'citations', 'citations': unique_citations})}\n\n"
-        
+
         # Send completion signal
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
-                        
+
     except Exception as e:
-        print(f"[ERROR] Streaming failed: {e}")
+        logger.error("Streaming failed: %s", e)
         yield f"data: {json.dumps({'type': 'error', 'content': f'Streaming failed: {e}'})}\n\n"
 
-async def handle_tool_follow_up(original_payload: Dict[str, Any], tool_call: Dict[str, Any], tool_result: str, citations_collector: List[str]) -> AsyncGenerator[str, None]:
+
+async def handle_tool_follow_up(
+    original_payload: Dict[str, Any],
+    tool_call: Dict[str, Any],
+    tool_result: str,
+    citations_collector: List[str],
+) -> AsyncGenerator[str, None]:
     """Handle follow-up request after tool execution"""
     try:
-        print("[TOOL] Handling follow-up request with tool results")
-        
+        logger.info("Handling follow-up request with tool results")
+
         # Create messages with tool call and result
         messages = original_payload["messages"].copy()
-        
+
         # Add assistant's tool call message
-        messages.append({
-            "role": "assistant",
-            "tool_calls": [tool_call]
-        })
-        
+        messages.append({"role": "assistant", "tool_calls": [tool_call]})
+
         # Add tool result message
-        messages.append({
-            "role": "tool",
-            "tool_call_id": tool_call["id"],
-            "content": tool_result
-        })
-        
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call["id"],
+                "content": tool_result,
+            }
+        )
+
         # Create follow-up payload - remove tools to get final response
         follow_up_payload = {
             "model": original_payload["model"],
             "messages": messages,
             "stream": True,
-            "max_tokens": 1000
+            "max_tokens": 1000,
         }
-        
+
         # Stream the follow-up response
         async for chunk in stream_llm_response(follow_up_payload):
             yield chunk
-        
+
     except Exception as e:
-        print(f"[ERROR] Tool follow-up failed: {e}")
+        logger.error("Tool follow-up failed: %s", e)
         yield f"data: {json.dumps({'type': 'error', 'content': f'Tool follow-up failed: {e}'})}\n\n"
 
-async def get_non_streaming_response(payload: Dict[str, Any]) -> tuple[str, List[str]]:
+
+async def get_non_streaming_response(
+    payload: Dict[str, Any],
+) -> tuple[str, List[str]]:
     """Get non-streaming response by collecting all streaming chunks"""
     response_content = ""
-    citations = []
-    
+    citations: List[str] = []
+
     async for chunk in stream_llm_response(payload):
         if chunk.startswith("data: "):
             try:
@@ -362,56 +240,54 @@ async def get_non_streaming_response(payload: Dict[str, Any]) -> tuple[str, List
                 elif data.get("type") == "citations":
                     citations.extend(data.get("citations", []))
                 elif data.get("type") == "error":
-                    raise HTTPException(status_code=500, detail=data.get("content", "Unknown error"))
+                    raise HTTPException(
+                        status_code=500,
+                        detail=data.get("content", "Unknown error"),
+                    )
             except json.JSONDecodeError:
                 continue
-    
+
     return response_content, citations
+
 
 @app.get("/")
 async def hello():
     """Simple hello endpoint"""
     return {"message": "Hello from Kubeflow Docs API!", "service": "https-api"}
 
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint for Kubernetes probes"""
     return {"status": "healthy", "service": "https-api"}
+
 
 @app.options("/chat")
 async def options_chat():
     """Handle preflight OPTIONS request"""
     return {"message": "OK"}
 
+
 @app.options("/")
 async def options_root():
     """Handle preflight OPTIONS request for root"""
     return {"message": "OK"}
+
 
 @app.options("/health")
 async def options_health():
     """Handle preflight OPTIONS request for health"""
     return {"message": "OK"}
 
+
 @app.post("/chat")
 async def chat(request: ChatRequest):
     """Chat endpoint with RAG capabilities - supports both streaming and non-streaming"""
     try:
-        print(f"[CHAT] Processing message: {request.message[:100]}...")
-        
-        # Create initial payload
-        payload = {
-            "model": MODEL,
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": request.message}
-            ],
-            "tools": TOOLS,
-            "tool_choice": "auto",
-            "stream": True,
-            "max_tokens": 1500
-        }
-        
+        logger.info("Processing message: %s...", request.message[:100])
+
+        payload = build_chat_payload(request.message)
+
         if request.stream:
             # Return streaming response using Server-Sent Events
             return StreamingResponse(
@@ -421,27 +297,23 @@ async def chat(request: ChatRequest):
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
                     "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Headers": "Cache-Control"
-                }
+                    "Access-Control-Allow-Headers": "Cache-Control",
+                },
             )
         else:
             # Return non-streaming JSON response
             response_content, citations = await get_non_streaming_response(payload)
-            
-            # Remove duplicates from citations while preserving order
-            unique_citations = []
-            for citation in citations:
-                if citation not in unique_citations:
-                    unique_citations.append(citation)
-            
+            unique_citations = deduplicate_citations(citations)
+
             return {
                 "response": response_content,
-                "citations": unique_citations if unique_citations else None
+                "citations": unique_citations if unique_citations else None,
             }
-        
+
     except Exception as e:
-        print(f"[ERROR] Chat handling failed: {e}")
+        logger.error("Chat handling failed: %s", e)
         raise HTTPException(status_code=500, detail=f"Request failed: {e}")
+
 
 if __name__ == "__main__":
     print("🚀 Starting Kubeflow Docs HTTP API Server")
@@ -449,9 +321,5 @@ if __name__ == "__main__":
     print(f"   LLM Service: {KSERVE_URL}")
     print(f"   Milvus: {MILVUS_HOST}:{MILVUS_PORT}")
     print(f"   Collection: {MILVUS_COLLECTION}")
-    
-    uvicorn.run(
-        app, 
-        host="0.0.0.0", 
-        port=PORT
-    )
+
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/server-https/requirements.txt
+++ b/server-https/requirements.txt
@@ -6,4 +6,3 @@ sentence-transformers
 pymilvus
 torch --extra-index-url https://download.pytorch.org/whl/cpu
 numpy
-beautifulsoup4

--- a/server-https/requirements.txt
+++ b/server-https/requirements.txt
@@ -6,3 +6,4 @@ sentence-transformers
 pymilvus
 torch --extra-index-url https://download.pytorch.org/whl/cpu
 numpy
+beautifulsoup4

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p $HF_HOME $SENTENCE_TRANSFORMERS_HOME $XDG_CACHE_HOME && \
 USER appuser
 
 # App
+COPY shared/ /app/shared/
 COPY app.py /app/
 
 EXPOSE 8000

--- a/server/app.py
+++ b/server/app.py
@@ -1,392 +1,285 @@
-import os
 import json
 import asyncio
-import httpx
+import logging
+import sys
+import os
+
 import websockets
 from websockets.server import serve
 from websockets.exceptions import ConnectionClosedError
-import logging
+
+# Add project root to path so shared module is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from shared.rag_core import (  # noqa: E402
+    KSERVE_URL,
+    MODEL,
+    MILVUS_HOST,
+    MILVUS_PORT,
+    MILVUS_COLLECTION,
+    PORT,
+    SYSTEM_PROMPT,
+    TOOLS,
+    execute_tool,
+    deduplicate_citations,
+    build_chat_payload,
+)
+
 from typing import Dict, Any, List
-from sentence_transformers import SentenceTransformer
-from pymilvus import connections, Collection
 
-# Config
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
-MODEL = os.getenv("MODEL", "llama3.1-8B")
-PORT = int(os.getenv("PORT", "8000"))
-
-# Milvus Config
-MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local")
-MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
-MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
-MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
-
-# System prompt
-SYSTEM_PROMPT = """
-You are the Kubeflow Docs Assistant.
-
-!!IMPORTANT!!
-- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
-- You should never output the raw tool call to the user.
-
-Your role
-- Always answer the user's question directly.
-- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
-- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
-
-Tool Use
-- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
-- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
-- When you do call the tool:
-  • Use one clear, focused query.  
-  • Summarize the result in your own words.  
-  • If no results are relevant, say “not found in the docs” and suggest refining the query.
-- Example usage:
-  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
-  - You should make a tool call to search the docs with a query "kubeflow setup".
-
-  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
-  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
-
-The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
-
-Routing
-- Greetings/small talk → respond briefly, no tool.  
-- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
-- Kubeflow-specific → answer and call the tool if documentation is needed.  
-
-Style
-- Be concise (2–5 sentences). Use bullet points or steps when helpful.
-- Provide examples only when asked.
-- Never invent features. If unsure, say so.
-- Reply in clean Markdown.
-"""
+logger = logging.getLogger(__name__)
 
 
-
-def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
-    """Execute a semantic search in Milvus and return structured JSON serializable results."""
-    try:
-        # Connect to Milvus
-        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
-        collection = Collection(MILVUS_COLLECTION)
-        collection.load()
-
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
-
-        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
-        results = collection.search(
-            data=[query_vec],
-            anns_field=MILVUS_VECTOR_FIELD,
-            param=search_params,
-            limit=int(top_k),
-            output_fields=["file_path", "content_text", "citation_url"],
-        )
-
-        hits = []
-        for hit in results[0]:
-            # similarity = 1 - distance for COSINE in Milvus
-            similarity = 1.0 - float(hit.distance)
-            entity = hit.entity
-            content_text = entity.get("content_text") or ""
-            if isinstance(content_text, str) and len(content_text) > 400:
-                content_text = content_text[:400] + "..."
-            hits.append({
-                "similarity": similarity,
-                "file_path": entity.get("file_path"),
-                "citation_url": entity.get("citation_url"),
-                "content_text": content_text,
-            })
-        return {"results": hits}
-    except Exception as e:
-        print(f"[ERROR] Milvus search failed: {e}")
-        return {"results": []}
-    finally:
-        try:
-            connections.disconnect(alias="default")
-        except Exception:
-            pass
-TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "search_kubeflow_docs",
-            "description": (
-                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
-                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
-                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
-                        "minLength": 1
-                    },
-                    "top_k": {
-                        "type": "integer",
-                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
-                        "default": 5,
-                        "minimum": 1,
-                        "maximum": 10
-                    }
-                },
-                "required": ["query"],
-                "additionalProperties": False
-            }
-        }
-    }
-]
-
-
-async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
-    """Execute a tool call and return the result and citations"""
-    try:
-        function_name = tool_call.get("function", {}).get("name")
-        arguments = json.loads(tool_call.get("function", {}).get("arguments", "{}"))
-        
-        if function_name == "search_kubeflow_docs":
-            query = arguments.get("query", "")
-            top_k = arguments.get("top_k", 5)
-            
-            print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, top_k)
-            
-            # Collect citations
-            citations = []
-            formatted_results = []
-            
-            for hit in result.get("results", []):
-                citation_url = hit.get('citation_url', '')
-                if citation_url and citation_url not in citations:
-                    citations.append(citation_url)
-                
-                formatted_results.append(
-                    f"File: {hit.get('file_path', 'Unknown')}\n"
-                    f"Content: {hit.get('content_text', '')}\n"
-                    f"URL: {citation_url}\n"
-                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
-                )
-            
-            formatted_text = "\n".join(formatted_results) if formatted_results else "No relevant results found."
-            return formatted_text, citations
-        
-        return f"Unknown tool: {function_name}", []
-        
-    except Exception as e:
-        print(f"[ERROR] Tool execution failed: {e}")
-        return f"Tool execution failed: {e}", []
-
-async def stream_llm_response(payload: Dict[str, Any], websocket, citations_collector: List[str] = None) -> None:
+async def stream_llm_response(
+    payload: Dict[str, Any],
+    websocket,
+    citations_collector: List[str] = None,
+) -> None:
     """Stream response from LLM to websocket, handling tool calls"""
     if citations_collector is None:
         citations_collector = []
     try:
+        import httpx
+
         async with httpx.AsyncClient(timeout=120) as client:
             async with client.stream("POST", KSERVE_URL, json=payload) as response:
                 if response.status_code != 200:
                     error_msg = f"LLM service error: HTTP {response.status_code}"
-                    print(f"[ERROR] {error_msg}")
-                    await websocket.send(json.dumps({"type": "error", "content": error_msg}))
+                    logger.error(error_msg)
+                    await websocket.send(
+                        json.dumps({"type": "error", "content": error_msg})
+                    )
                     return
-                
+
                 # Buffer for accumulating tool calls
                 tool_calls_buffer = {}
-                
+
                 async for line in response.aiter_lines():
                     if not line.startswith("data: "):
                         continue
-                    
+
                     data = line[6:]  # Remove "data: " prefix
                     if data == "[DONE]":
                         break
-                    
+
                     try:
                         chunk = json.loads(data)
                         choices = chunk.get("choices", [])
                         if not choices:
                             continue
-                            
+
                         delta = choices[0].get("delta", {})
                         finish_reason = choices[0].get("finish_reason")
-                        
+
                         # Handle tool calls in streaming
                         if "tool_calls" in delta:
                             tool_calls = delta["tool_calls"]
                             for tool_call in tool_calls:
                                 index = tool_call.get("index", 0)
-                                
+
                                 # Initialize tool call buffer if needed
                                 if index not in tool_calls_buffer:
                                     tool_calls_buffer[index] = {
                                         "id": tool_call.get("id", ""),
                                         "type": tool_call.get("type", "function"),
                                         "function": {
-                                            "name": tool_call.get("function", {}).get("name", ""),
-                                            "arguments": ""
-                                        }
+                                            "name": tool_call.get("function", {}).get(
+                                                "name", ""
+                                            ),
+                                            "arguments": "",
+                                        },
                                     }
-                                
+
                                 # Update tool call data
                                 if tool_call.get("id"):
                                     tool_calls_buffer[index]["id"] = tool_call["id"]
                                 if tool_call.get("type"):
                                     tool_calls_buffer[index]["type"] = tool_call["type"]
-                                
+
                                 function_data = tool_call.get("function", {})
                                 if function_data.get("name"):
-                                    tool_calls_buffer[index]["function"]["name"] = function_data["name"]
+                                    tool_calls_buffer[index]["function"]["name"] = (
+                                        function_data["name"]
+                                    )
                                 if "arguments" in function_data:
-                                    tool_calls_buffer[index]["function"]["arguments"] += function_data["arguments"]
-                        
+                                    tool_calls_buffer[index]["function"][
+                                        "arguments"
+                                    ] += function_data["arguments"]
+
                         # Handle regular content
                         elif "content" in delta and delta["content"]:
-                            await websocket.send(json.dumps({
-                                "type": "content", 
-                                "content": delta["content"]
-                            }))
-                        
+                            await websocket.send(
+                                json.dumps(
+                                    {"type": "content", "content": delta["content"]}
+                                )
+                            )
+
                         # Handle finish reason - execute tools if needed
                         if finish_reason == "tool_calls":
-                            print(f"[TOOL] Finish reason: tool_calls, executing {len(tool_calls_buffer)} tools")
-                            
+                            logger.info(
+                                "Finish reason: tool_calls, executing %d tools",
+                                len(tool_calls_buffer),
+                            )
+
                             # Execute all accumulated tool calls
                             for tool_call in tool_calls_buffer.values():
-                                if tool_call["function"]["name"] and tool_call["function"]["arguments"]:
+                                if (
+                                    tool_call["function"]["name"]
+                                    and tool_call["function"]["arguments"]
+                                ):
                                     try:
-                                        print(f"[TOOL] Executing: {tool_call['function']['name']}")
-                                        print(f"[TOOL] Arguments: {tool_call['function']['arguments']}")
-                                        
-                                        result, tool_citations = await execute_tool(tool_call)
-                                        
+                                        logger.info(
+                                            "Executing: %s",
+                                            tool_call["function"]["name"],
+                                        )
+
+                                        result, tool_citations = await execute_tool(
+                                            tool_call
+                                        )
+
                                         # Collect citations
                                         citations_collector.extend(tool_citations)
-                                        
+
                                         # Send tool execution result to client
-                                        await websocket.send(json.dumps({
-                                            "type": "tool_result",
-                                            "tool_name": tool_call["function"]["name"],
-                                            "content": result
-                                        }))
-                                        
+                                        await websocket.send(
+                                            json.dumps(
+                                                {
+                                                    "type": "tool_result",
+                                                    "tool_name": tool_call["function"][
+                                                        "name"
+                                                    ],
+                                                    "content": result,
+                                                }
+                                            )
+                                        )
+
                                         # Make follow-up request with tool results
-                                        await handle_tool_follow_up(payload, tool_call, result, websocket, citations_collector)
-                                        
+                                        await handle_tool_follow_up(
+                                            payload,
+                                            tool_call,
+                                            result,
+                                            websocket,
+                                            citations_collector,
+                                        )
+
                                     except Exception as e:
-                                        print(f"[ERROR] Tool execution error: {e}")
-                                        await websocket.send(json.dumps({
-                                            "type": "error",
-                                            "content": f"Tool execution failed: {e}"
-                                        }))
-                            
+                                        logger.error("Tool execution error: %s", e)
+                                        await websocket.send(
+                                            json.dumps(
+                                                {
+                                                    "type": "error",
+                                                    "content": f"Tool execution failed: {e}",
+                                                }
+                                            )
+                                        )
+
                             tool_calls_buffer.clear()
                             break  # Tool execution complete, exit streaming loop
-                            
-                    except json.JSONDecodeError as e:
-                        print(f"[ERROR] JSON decode error: {e}, line: {line}")
-                        continue
-                        
-    except Exception as e:
-        print(f"[ERROR] Streaming failed: {e}")
-        await websocket.send(json.dumps({"type": "error", "content": f"Streaming failed: {e}"}))
 
-async def handle_tool_follow_up(original_payload: Dict[str, Any], tool_call: Dict[str, Any], tool_result: str, websocket, citations_collector: List[str] = None) -> None:
+                    except json.JSONDecodeError as e:
+                        logger.error("JSON decode error: %s, line: %s", e, line)
+                        continue
+
+    except Exception as e:
+        logger.error("Streaming failed: %s", e)
+        await websocket.send(
+            json.dumps({"type": "error", "content": f"Streaming failed: {e}"})
+        )
+
+
+async def handle_tool_follow_up(
+    original_payload: Dict[str, Any],
+    tool_call: Dict[str, Any],
+    tool_result: str,
+    websocket,
+    citations_collector: List[str] = None,
+) -> None:
     """Handle follow-up request after tool execution"""
     if citations_collector is None:
         citations_collector = []
     try:
-        print("[TOOL] Handling follow-up request with tool results")
-        
+        logger.info("Handling follow-up request with tool results")
+
         # Create messages with tool call and result
         messages = original_payload["messages"].copy()
-        
+
         # Add assistant's tool call message
-        messages.append({
-            "role": "assistant",
-            "tool_calls": [tool_call]
-        })
-        
+        messages.append({"role": "assistant", "tool_calls": [tool_call]})
+
         # Add tool result message
-        messages.append({
-            "role": "tool",
-            "tool_call_id": tool_call["id"],
-            "content": tool_result
-        })
-        
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call["id"],
+                "content": tool_result,
+            }
+        )
+
         # Create follow-up payload - remove tools to get final response
         follow_up_payload = {
             "model": original_payload["model"],
             "messages": messages,
             "stream": True,
-            "max_tokens": 1000
+            "max_tokens": 1000,
         }
-        
+
         # Stream the follow-up response
         await stream_llm_response(follow_up_payload, websocket, citations_collector)
-        
+
     except Exception as e:
-        print(f"[ERROR] Tool follow-up failed: {e}")
-        await websocket.send(json.dumps({"type": "error", "content": f"Tool follow-up failed: {e}"}))
+        logger.error("Tool follow-up failed: %s", e)
+        await websocket.send(
+            json.dumps(
+                {"type": "error", "content": f"Tool follow-up failed: {e}"}
+            )
+        )
+
 
 async def handle_chat(message: str, websocket) -> None:
     """Handle chat with tool calling support"""
     try:
-        print(f"[CHAT] Processing message: {message[:100]}...")
-        
-        # Create initial payload
-        payload = {
-            "model": MODEL,
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": message}
-            ],
-            "tools": TOOLS,
-            "tool_choice": "auto",
-            "stream": True,
-            "max_tokens": 1500
-        }
-        
+        logger.info("Processing message: %s...", message[:100])
+
+        payload = build_chat_payload(message)
+
         # Collect citations throughout the conversation
-        citations_collector = []
-        
+        citations_collector: List[str] = []
+
         # Start streaming response
         await stream_llm_response(payload, websocket, citations_collector)
-        
+
         # Send citations if any were collected
         if citations_collector:
-            # Remove duplicates while preserving order
-            unique_citations = []
-            for citation in citations_collector:
-                if citation not in unique_citations:
-                    unique_citations.append(citation)
-            
-            await websocket.send(json.dumps({
-                "type": "citations", 
-                "citations": unique_citations
-            }))
-        
+            unique_citations = deduplicate_citations(citations_collector)
+            await websocket.send(
+                json.dumps({"type": "citations", "citations": unique_citations})
+            )
+
         # Send completion signal
         await websocket.send(json.dumps({"type": "done"}))
-        
+
     except Exception as e:
-        print(f"[ERROR] Chat handling failed: {e}")
-        await websocket.send(json.dumps({"type": "error", "content": f"Request failed: {e}"}))
+        logger.error("Chat handling failed: %s", e)
+        await websocket.send(
+            json.dumps({"type": "error", "content": f"Request failed: {e}"})
+        )
+
 
 async def handle_websocket(websocket, path):
     """Handle WebSocket connections"""
-    print(f"[WS] New connection from {websocket.remote_address}")
-    
+    logger.info("New connection from %s", websocket.remote_address)
+
     try:
         # Send welcome message
-        await websocket.send(json.dumps({
-            "type": "system",
-            "content": "Connected to Kubeflow Documentation Assistant"
-        }))
-        
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "system",
+                    "content": "Connected to Kubeflow Documentation Assistant",
+                }
+            )
+        )
+
         async for message in websocket:
             try:
                 # Ensure we always deal with string, not bytes
@@ -402,26 +295,32 @@ async def handle_websocket(websocket, path):
                     # Treat as plain text message
                     pass
 
-                print(f"[WS] Received: {message[:100]}...")
+                logger.info("Received: %s...", message[:100])
                 await handle_chat(message, websocket)
-                
+
             except Exception as e:
-                print(f"[ERROR] Message processing error: {e}")
-                await websocket.send(json.dumps({
-                    "type": "error", 
-                    "content": f"Message processing failed: {e}"
-                }))
-                
+                logger.error("Message processing error: %s", e)
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "content": f"Message processing failed: {e}",
+                        }
+                    )
+                )
+
     except ConnectionClosedError:
-        print("[WS] Connection closed")
+        logger.info("Connection closed")
     except Exception as e:
-        print(f"[ERROR] WebSocket error: {e}")
+        logger.error("WebSocket error: %s", e)
+
 
 async def health_check(path, request_headers):
     """Handle HTTP health checks"""
     if path == "/health":
         return 200, [("Content-Type", "text/plain")], b"OK"
     return None
+
 
 async def main():
     """Start the WebSocket server"""
@@ -430,25 +329,27 @@ async def main():
     print(f"   LLM Service: {KSERVE_URL}")
     print(f"   Milvus: {MILVUS_HOST}:{MILVUS_PORT}")
     print(f"   Collection: {MILVUS_COLLECTION}")
-    
+
     # Configure logging
+    logging.basicConfig(level=logging.INFO)
     logging.getLogger("websockets").setLevel(logging.WARNING)
-    
+
     # Start server
     async with serve(
-        handle_websocket, 
-        "0.0.0.0", 
+        handle_websocket,
+        "0.0.0.0",
         PORT,
         process_request=health_check,
         ping_interval=30,
-        ping_timeout=10
+        ping_timeout=10,
     ):
         print("✅ WebSocket server is running...")
         print(f"   WebSocket: ws://localhost:{PORT}")
         print(f"   Health: http://localhost:{PORT}/health")
-        
+
         # Keep server running
         await asyncio.Future()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/server/app.py
+++ b/server/app.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import sys
 import os
+import httpx
 
 import websockets
 from websockets.server import serve
@@ -39,7 +40,6 @@ async def stream_llm_response(
     if citations_collector is None:
         citations_collector = []
     try:
-        import httpx
 
         async with httpx.AsyncClient(timeout=120) as client:
             async with client.stream("POST", KSERVE_URL, json=payload) as response:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,4 +11,3 @@ torch --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Essential only
 numpy
-beautifulsoup4

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,3 +11,4 @@ torch --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Essential only
 numpy
+beautifulsoup4

--- a/shared/rag_core.py
+++ b/shared/rag_core.py
@@ -12,6 +12,8 @@ from typing import Dict, Any, List, Tuple
 
 from sentence_transformers import SentenceTransformer
 from pymilvus import connections, Collection
+import httpx
+from bs4 import BeautifulSoup
 
 # ---------------------------------------------------------------------------
 # Configuration (environment-driven with sensible defaults)

--- a/shared/rag_core.py
+++ b/shared/rag_core.py
@@ -8,12 +8,10 @@ functions used by both the WebSocket and HTTPS API servers.
 import os
 import json
 import logging
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Set, Tuple
 
 from sentence_transformers import SentenceTransformer
 from pymilvus import connections, Collection
-import httpx
-from bs4 import BeautifulSoup
 
 # ---------------------------------------------------------------------------
 # Configuration (environment-driven with sensible defaults)
@@ -221,7 +219,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> Tuple[str, List[str]]:
 
 def deduplicate_citations(citations: List[str]) -> List[str]:
     """Remove duplicate citations while preserving order."""
-    seen: set[str] = set()
+    seen: Set[str] = set()
     unique: List[str] = []
     for citation in citations:
         if citation not in seen:

--- a/shared/rag_core.py
+++ b/shared/rag_core.py
@@ -1,0 +1,250 @@
+"""
+Shared RAG utilities for the Kubeflow Documentation AI Assistant.
+
+This module contains shared configuration, prompts, tools, and utility
+functions used by both the WebSocket and HTTPS API servers.
+"""
+
+import os
+import json
+import logging
+from typing import Dict, Any, List, Tuple
+
+from sentence_transformers import SentenceTransformer
+from pymilvus import connections, Collection
+
+# ---------------------------------------------------------------------------
+# Configuration (environment-driven with sensible defaults)
+# ---------------------------------------------------------------------------
+
+KSERVE_URL = os.getenv(
+    "KSERVE_URL",
+    "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions",
+)
+MODEL = os.getenv("MODEL", "llama3.1-8B")
+PORT = int(os.getenv("PORT", "8000"))
+
+# Milvus
+MILVUS_HOST = os.getenv(
+    "MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local"
+)
+MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
+MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
+EMBEDDING_MODEL = os.getenv(
+    "EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2"
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """
+You are the Kubeflow Docs Assistant.
+
+!!IMPORTANT!!
+- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
+- You should never output the raw tool call to the user.
+
+Your role
+- Always answer the user's question directly.
+- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
+- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
+
+Tool Use
+- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
+- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
+- When you do call the tool:
+  • Use one clear, focused query.  
+  • Summarize the result in your own words.  
+  • If no results are relevant, say "not found in the docs" and suggest refining the query.
+- Example usage:
+  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
+  - You should make a tool call to search the docs with a query "kubeflow setup".
+
+  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
+  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
+
+The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
+
+Routing
+- Greetings/small talk → respond briefly, no tool.  
+- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
+- Kubeflow-specific → answer and call the tool if documentation is needed.  
+
+Style
+- Be concise (2–5 sentences). Use bullet points or steps when helpful.
+- Provide examples only when asked.
+- Never invent features. If unsure, say so.
+- Reply in clean Markdown.
+"""
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_kubeflow_docs",
+            "description": (
+                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
+                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
+                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
+                        "minLength": 1,
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 10,
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+# ---------------------------------------------------------------------------
+# Milvus semantic search
+# ---------------------------------------------------------------------------
+
+
+def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
+    """Execute a semantic search in Milvus and return structured JSON-serializable results."""
+    try:
+        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
+        collection = Collection(MILVUS_COLLECTION)
+        collection.load()
+
+        encoder = SentenceTransformer(EMBEDDING_MODEL)
+        query_vec = encoder.encode(query).tolist()
+
+        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
+        results = collection.search(
+            data=[query_vec],
+            anns_field=MILVUS_VECTOR_FIELD,
+            param=search_params,
+            limit=int(top_k),
+            output_fields=["file_path", "content_text", "citation_url"],
+        )
+
+        hits = []
+        for hit in results[0]:
+            similarity = 1.0 - float(hit.distance)
+            entity = hit.entity
+            content_text = entity.get("content_text") or ""
+            if isinstance(content_text, str) and len(content_text) > 400:
+                content_text = content_text[:400] + "..."
+            hits.append(
+                {
+                    "similarity": similarity,
+                    "file_path": entity.get("file_path"),
+                    "citation_url": entity.get("citation_url"),
+                    "content_text": content_text,
+                }
+            )
+        return {"results": hits}
+    except Exception as e:
+        logger.error("Milvus search failed: %s", e)
+        return {"results": []}
+    finally:
+        try:
+            connections.disconnect(alias="default")
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Tool execution
+# ---------------------------------------------------------------------------
+
+
+async def execute_tool(tool_call: Dict[str, Any]) -> Tuple[str, List[str]]:
+    """Execute a tool call and return ``(result_text, citations)``."""
+    try:
+        function_name = tool_call.get("function", {}).get("name")
+        arguments = json.loads(
+            tool_call.get("function", {}).get("arguments", "{}")
+        )
+
+        if function_name == "search_kubeflow_docs":
+            query = arguments.get("query", "")
+            top_k = arguments.get("top_k", 5)
+
+            logger.info("Executing Milvus search for: '%s' (top_k=%s)", query, top_k)
+            result = milvus_search(query, top_k)
+
+            citations: List[str] = []
+            formatted_results: List[str] = []
+
+            for hit in result.get("results", []):
+                citation_url = hit.get("citation_url", "")
+                if citation_url and citation_url not in citations:
+                    citations.append(citation_url)
+
+                formatted_results.append(
+                    f"File: {hit.get('file_path', 'Unknown')}\n"
+                    f"Content: {hit.get('content_text', '')}\n"
+                    f"URL: {citation_url}\n"
+                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
+                )
+
+            formatted_text = (
+                "\n".join(formatted_results)
+                if formatted_results
+                else "No relevant results found."
+            )
+            return formatted_text, citations
+
+        return f"Unknown tool: {function_name}", []
+
+    except Exception as e:
+        logger.error("Tool execution failed: %s", e)
+        return f"Tool execution failed: {e}", []
+
+
+def deduplicate_citations(citations: List[str]) -> List[str]:
+    """Remove duplicate citations while preserving order."""
+    seen: set[str] = set()
+    unique: List[str] = []
+    for citation in citations:
+        if citation not in seen:
+            seen.add(citation)
+            unique.append(citation)
+    return unique
+
+
+def build_chat_payload(
+    message: str,
+    *,
+    include_tools: bool = True,
+    max_tokens: int = 1500,
+) -> Dict[str, Any]:
+    """Build the initial chat payload for the LLM."""
+    payload: Dict[str, Any] = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": message},
+        ],
+        "stream": True,
+        "max_tokens": max_tokens,
+    }
+    if include_tools:
+        payload["tools"] = TOOLS
+        payload["tool_choice"] = "auto"
+    return payload


### PR DESCRIPTION
## Summary

Adds `eval/` — a retrieval evaluation framework for measuring RAG quality:

- **Golden Dataset**: 35 curated queries across 3 intent categories (kubeflow-specific, platform-architecture, general), each with expected source URL patterns.
- **Metrics**: Recall@k, Precision@k, Mean Reciprocal Rank (MRR).
- **CLI Interface**: `python eval/evaluate.py --dry-run` for CI validation (schema/structure checks without Milvus), `--output results.json` for persisting evaluation results.
- **Extensible**: Designed to work with live Milvus or be extended with mock/recorded backends for offline testing.

## Usage

```bash
# Dry run (validates dataset + code without Milvus)
python eval/evaluate.py --dry-run

# Full evaluation against live Milvus
python eval/evaluate.py --top-k 5 --output eval_results.json
```

## Depends on

This PR is stacked on #49 (refactor: extract shared config and utilities for API servers).

## Related Issues

- Part of #60 (GSoC 2026: Agentic RAG on Kubeflow)