### PR TITLE
feat(terraform): add OCI/OKE deployment scaffolding for docs-agent

### DIFF
--- a/server-https/Dockerfile
+++ b/server-https/Dockerfile
@@ -15,6 +15,7 @@ ENV PORT=8000
 USER appuser
 
 # App
+COPY shared/ /app/shared/
 COPY app.py /app/
 
 EXPOSE 8000

--- a/server-https/app.py
+++ b/server-https/app.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 import os
+from typing import Dict, Any, List, AsyncGenerator
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -10,22 +11,42 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
 
-# Add project root to path so shared module is importable
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from shared.rag_core import (  # noqa: E402
-    KSERVE_URL,
-    MODEL,
-    MILVUS_HOST,
-    MILVUS_PORT,
-    MILVUS_COLLECTION,
-    PORT,
-    execute_tool,
-    deduplicate_citations,
-    build_chat_payload,
-)
-
-from typing import Dict, Any, List, AsyncGenerator
+# Import shared module, supporting both installed-package and repo layouts
+try:
+    from shared.rag_core import (
+        KSERVE_URL,
+        MODEL,
+        MILVUS_HOST,
+        MILVUS_PORT,
+        MILVUS_COLLECTION,
+        PORT,
+        execute_tool,
+        deduplicate_citations,
+        build_chat_payload,
+    )
+except ModuleNotFoundError as _original_exc:
+    # Fallback for development: add project root so ../shared is importable
+    _project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if _project_root not in sys.path:
+        sys.path.insert(0, _project_root)
+    try:
+        from shared.rag_core import (
+            KSERVE_URL,
+            MODEL,
+            MILVUS_HOST,
+            MILVUS_PORT,
+            MILVUS_COLLECTION,
+            PORT,
+            execute_tool,
+            deduplicate_citations,
+            build_chat_payload,
+        )
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "Could not import 'shared.rag_core'. Ensure the 'shared/' directory "
+            "is available on PYTHONPATH or copied into the runtime environment "
+            "(for Docker, include 'COPY shared/ /app/shared/')."
+        ) from _original_exc
 
 logger = logging.getLogger(__name__)
 

--- a/server-https/app.py
+++ b/server-https/app.py
@@ -1,100 +1,33 @@
-import os
 import json
+import logging
+import sys
+import os
+
 import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
-from typing import Dict, Any, List, Optional, AsyncGenerator
-from sentence_transformers import SentenceTransformer
-from pymilvus import connections, Collection
 
-# Config
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
-MODEL = os.getenv("MODEL", "llama3.1-8B")
-PORT = int(os.getenv("PORT", "8000"))
+# Add project root to path so shared module is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-# Milvus Config
-MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local")
-MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
-MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
-MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
+from shared.rag_core import (  # noqa: E402
+    KSERVE_URL,
+    MODEL,
+    MILVUS_HOST,
+    MILVUS_PORT,
+    MILVUS_COLLECTION,
+    PORT,
+    execute_tool,
+    deduplicate_citations,
+    build_chat_payload,
+)
 
-# System prompt (same as WebSocket version)
-SYSTEM_PROMPT = """
-You are the Kubeflow Docs Assistant.
+from typing import Dict, Any, List, AsyncGenerator
 
-!!IMPORTANT!!
-- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
-- You should never output the raw tool call to the user.
-
-Your role
-- Always answer the user's question directly.
-- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
-- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
-
-Tool Use
-- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
-- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
-- When you do call the tool:
-  • Use one clear, focused query.  
-  • Summarize the result in your own words.  
-  • If no results are relevant, say "not found in the docs" and suggest refining the query.
-- Example usage:
-  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
-  - You should make a tool call to search the docs with a query "kubeflow setup".
-
-  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
-  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
-
-The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
-
-Routing
-- Greetings/small talk → respond briefly, no tool.  
-- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
-- Kubeflow-specific → answer and call the tool if documentation is needed.  
-
-Style
-- Be concise (2–5 sentences). Use bullet points or steps when helpful.
-- Provide examples only when asked.
-- Never invent features. If unsure, say so.
-- Reply in clean Markdown.
-"""
-
-TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "search_kubeflow_docs",
-            "description": (
-                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
-                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
-                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
-                        "minLength": 1
-                    },
-                    "top_k": {
-                        "type": "integer",
-                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
-                        "default": 5,
-                        "minimum": 1,
-                        "maximum": 10
-                    }
-                },
-                "required": ["query"],
-                "additionalProperties": False
-            }
-        }
-    }
-]
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Kubeflow Docs API Service", version="1.0.0")
 
@@ -107,252 +40,197 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 class ChatRequest(BaseModel):
     message: str
-    stream: Optional[bool] = True
+    stream: bool = True
 
-def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
-    """Execute a semantic search in Milvus and return structured JSON serializable results."""
-    try:
-        # Connect to Milvus
-        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
-        collection = Collection(MILVUS_COLLECTION)
-        collection.load()
 
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
-
-        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
-        results = collection.search(
-            data=[query_vec],
-            anns_field=MILVUS_VECTOR_FIELD,
-            param=search_params,
-            limit=int(top_k),
-            output_fields=["file_path", "content_text", "citation_url"],
-        )
-
-        hits = []
-        for hit in results[0]:
-            # similarity = 1 - distance for COSINE in Milvus
-            similarity = 1.0 - float(hit.distance)
-            entity = hit.entity
-            content_text = entity.get("content_text") or ""
-            if isinstance(content_text, str) and len(content_text) > 400:
-                content_text = content_text[:400] + "..."
-            hits.append({
-                "similarity": similarity,
-                "file_path": entity.get("file_path"),
-                "citation_url": entity.get("citation_url"),
-                "content_text": content_text,
-            })
-        return {"results": hits}
-    except Exception as e:
-        print(f"[ERROR] Milvus search failed: {e}")
-        return {"results": []}
-    finally:
-        try:
-            connections.disconnect(alias="default")
-        except Exception:
-            pass
-
-async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
-    """Execute a tool call and return the result and citations"""
-    try:
-        function_name = tool_call.get("function", {}).get("name")
-        arguments = json.loads(tool_call.get("function", {}).get("arguments", "{}"))
-        
-        if function_name == "search_kubeflow_docs":
-            query = arguments.get("query", "")
-            top_k = arguments.get("top_k", 5)
-            
-            print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, top_k)
-            
-            # Collect citations
-            citations = []
-            formatted_results = []
-            
-            for hit in result.get("results", []):
-                citation_url = hit.get('citation_url', '')
-                if citation_url and citation_url not in citations:
-                    citations.append(citation_url)
-                
-                formatted_results.append(
-                    f"File: {hit.get('file_path', 'Unknown')}\n"
-                    f"Content: {hit.get('content_text', '')}\n"
-                    f"URL: {citation_url}\n"
-                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
-                )
-            
-            formatted_text = "\n".join(formatted_results) if formatted_results else "No relevant results found."
-            return formatted_text, citations
-        
-        return f"Unknown tool: {function_name}", []
-        
-    except Exception as e:
-        print(f"[ERROR] Tool execution failed: {e}")
-        return f"Tool execution failed: {e}", []
-
-async def stream_llm_response(payload: Dict[str, Any]) -> AsyncGenerator[str, None]:
+async def stream_llm_response(
+    payload: Dict[str, Any],
+) -> AsyncGenerator[str, None]:
     """Stream response from LLM and handle tool calls, yielding SSE events"""
-    citations_collector = []
-    
+    citations_collector: List[str] = []
+
     try:
         async with httpx.AsyncClient(timeout=120) as client:
             async with client.stream("POST", KSERVE_URL, json=payload) as response:
                 if response.status_code != 200:
                     error_msg = f"LLM service error: HTTP {response.status_code}"
-                    print(f"[ERROR] {error_msg}")
+                    logger.error(error_msg)
                     yield f"data: {json.dumps({'type': 'error', 'content': error_msg})}\n\n"
                     return
-                
+
                 # Buffer for accumulating tool calls
                 tool_calls_buffer = {}
-                
+
                 async for line in response.aiter_lines():
                     if not line.startswith("data: "):
                         continue
-                    
+
                     data = line[6:]  # Remove "data: " prefix
                     if data == "[DONE]":
                         break
-                    
+
                     try:
                         chunk = json.loads(data)
                         choices = chunk.get("choices", [])
                         if not choices:
                             continue
-                            
+
                         delta = choices[0].get("delta", {})
                         finish_reason = choices[0].get("finish_reason")
-                        
+
                         # Handle tool calls in streaming
                         if "tool_calls" in delta:
                             tool_calls = delta["tool_calls"]
                             for tool_call in tool_calls:
                                 index = tool_call.get("index", 0)
-                                
+
                                 # Initialize tool call buffer if needed
                                 if index not in tool_calls_buffer:
                                     tool_calls_buffer[index] = {
                                         "id": tool_call.get("id", ""),
                                         "type": tool_call.get("type", "function"),
                                         "function": {
-                                            "name": tool_call.get("function", {}).get("name", ""),
-                                            "arguments": ""
-                                        }
+                                            "name": tool_call.get("function", {}).get(
+                                                "name", ""
+                                            ),
+                                            "arguments": "",
+                                        },
                                     }
-                                
+
                                 # Update tool call data
                                 if tool_call.get("id"):
                                     tool_calls_buffer[index]["id"] = tool_call["id"]
                                 if tool_call.get("type"):
                                     tool_calls_buffer[index]["type"] = tool_call["type"]
-                                
+
                                 function_data = tool_call.get("function", {})
                                 if function_data.get("name"):
-                                    tool_calls_buffer[index]["function"]["name"] = function_data["name"]
+                                    tool_calls_buffer[index]["function"]["name"] = (
+                                        function_data["name"]
+                                    )
                                 if "arguments" in function_data:
-                                    tool_calls_buffer[index]["function"]["arguments"] += function_data["arguments"]
-                        
+                                    tool_calls_buffer[index]["function"][
+                                        "arguments"
+                                    ] += function_data["arguments"]
+
                         # Handle regular content
                         elif "content" in delta and delta["content"]:
                             yield f"data: {json.dumps({'type': 'content', 'content': delta['content']})}\n\n"
-                        
+
                         # Handle finish reason - execute tools if needed
                         if finish_reason == "tool_calls":
-                            print(f"[TOOL] Finish reason: tool_calls, executing {len(tool_calls_buffer)} tools")
-                            
+                            logger.info(
+                                "Finish reason: tool_calls, executing %d tools",
+                                len(tool_calls_buffer),
+                            )
+
                             # Execute all accumulated tool calls
                             for tool_call in tool_calls_buffer.values():
-                                if tool_call["function"]["name"] and tool_call["function"]["arguments"]:
+                                if (
+                                    tool_call["function"]["name"]
+                                    and tool_call["function"]["arguments"]
+                                ):
                                     try:
-                                        print(f"[TOOL] Executing: {tool_call['function']['name']}")
-                                        print(f"[TOOL] Arguments: {tool_call['function']['arguments']}")
-                                        
-                                        result, tool_citations = await execute_tool(tool_call)
-                                        
+                                        logger.info(
+                                            "Executing: %s",
+                                            tool_call["function"]["name"],
+                                        )
+
+                                        result, tool_citations = await execute_tool(
+                                            tool_call
+                                        )
+
                                         # Collect citations
                                         citations_collector.extend(tool_citations)
-                                        
+
                                         # Send tool execution result
                                         yield f"data: {json.dumps({'type': 'tool_result', 'tool_name': tool_call['function']['name'], 'content': result})}\n\n"
-                                        
+
                                         # Make follow-up request with tool results
-                                        async for follow_up_chunk in handle_tool_follow_up(payload, tool_call, result, citations_collector):
+                                        async for follow_up_chunk in handle_tool_follow_up(
+                                            payload,
+                                            tool_call,
+                                            result,
+                                            citations_collector,
+                                        ):
                                             yield follow_up_chunk
-                                        
+
                                     except Exception as e:
-                                        print(f"[ERROR] Tool execution error: {e}")
+                                        logger.error("Tool execution error: %s", e)
                                         yield f"data: {json.dumps({'type': 'error', 'content': f'Tool execution failed: {e}'})}\n\n"
-                            
+
                             tool_calls_buffer.clear()
                             break  # Tool execution complete, exit streaming loop
-                            
+
                     except json.JSONDecodeError as e:
-                        print(f"[ERROR] JSON decode error: {e}, line: {line}")
+                        logger.error("JSON decode error: %s, line: %s", e, line)
                         continue
-        
+
         # Send citations if any were collected
         if citations_collector:
-            # Remove duplicates while preserving order
-            unique_citations = []
-            for citation in citations_collector:
-                if citation not in unique_citations:
-                    unique_citations.append(citation)
-            
+            unique_citations = deduplicate_citations(citations_collector)
             yield f"data: {json.dumps({'type': 'citations', 'citations': unique_citations})}\n\n"
-        
+
         # Send completion signal
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
-                        
+
     except Exception as e:
-        print(f"[ERROR] Streaming failed: {e}")
+        logger.error("Streaming failed: %s", e)
         yield f"data: {json.dumps({'type': 'error', 'content': f'Streaming failed: {e}'})}\n\n"
 
-async def handle_tool_follow_up(original_payload: Dict[str, Any], tool_call: Dict[str, Any], tool_result: str, citations_collector: List[str]) -> AsyncGenerator[str, None]:
+
+async def handle_tool_follow_up(
+    original_payload: Dict[str, Any],
+    tool_call: Dict[str, Any],
+    tool_result: str,
+    citations_collector: List[str],
+) -> AsyncGenerator[str, None]:
     """Handle follow-up request after tool execution"""
     try:
-        print("[TOOL] Handling follow-up request with tool results")
-        
+        logger.info("Handling follow-up request with tool results")
+
         # Create messages with tool call and result
         messages = original_payload["messages"].copy()
-        
+
         # Add assistant's tool call message
-        messages.append({
-            "role": "assistant",
-            "tool_calls": [tool_call]
-        })
-        
+        messages.append({"role": "assistant", "tool_calls": [tool_call]})
+
         # Add tool result message
-        messages.append({
-            "role": "tool",
-            "tool_call_id": tool_call["id"],
-            "content": tool_result
-        })
-        
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call["id"],
+                "content": tool_result,
+            }
+        )
+
         # Create follow-up payload - remove tools to get final response
         follow_up_payload = {
             "model": original_payload["model"],
             "messages": messages,
             "stream": True,
-            "max_tokens": 1000
+            "max_tokens": 1000,
         }
-        
+
         # Stream the follow-up response
         async for chunk in stream_llm_response(follow_up_payload):
             yield chunk
-        
+
     except Exception as e:
-        print(f"[ERROR] Tool follow-up failed: {e}")
+        logger.error("Tool follow-up failed: %s", e)
         yield f"data: {json.dumps({'type': 'error', 'content': f'Tool follow-up failed: {e}'})}\n\n"
 
-async def get_non_streaming_response(payload: Dict[str, Any]) -> tuple[str, List[str]]:
+
+async def get_non_streaming_response(
+    payload: Dict[str, Any],
+) -> tuple[str, List[str]]:
     """Get non-streaming response by collecting all streaming chunks"""
     response_content = ""
-    citations = []
-    
+    citations: List[str] = []
+
     async for chunk in stream_llm_response(payload):
         if chunk.startswith("data: "):
             try:
@@ -362,56 +240,54 @@ async def get_non_streaming_response(payload: Dict[str, Any]) -> tuple[str, List
                 elif data.get("type") == "citations":
                     citations.extend(data.get("citations", []))
                 elif data.get("type") == "error":
-                    raise HTTPException(status_code=500, detail=data.get("content", "Unknown error"))
+                    raise HTTPException(
+                        status_code=500,
+                        detail=data.get("content", "Unknown error"),
+                    )
             except json.JSONDecodeError:
                 continue
-    
+
     return response_content, citations
+
 
 @app.get("/")
 async def hello():
     """Simple hello endpoint"""
     return {"message": "Hello from Kubeflow Docs API!", "service": "https-api"}
 
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint for Kubernetes probes"""
     return {"status": "healthy", "service": "https-api"}
+
 
 @app.options("/chat")
 async def options_chat():
     """Handle preflight OPTIONS request"""
     return {"message": "OK"}
 
+
 @app.options("/")
 async def options_root():
     """Handle preflight OPTIONS request for root"""
     return {"message": "OK"}
+
 
 @app.options("/health")
 async def options_health():
     """Handle preflight OPTIONS request for health"""
     return {"message": "OK"}
 
+
 @app.post("/chat")
 async def chat(request: ChatRequest):
     """Chat endpoint with RAG capabilities - supports both streaming and non-streaming"""
     try:
-        print(f"[CHAT] Processing message: {request.message[:100]}...")
-        
-        # Create initial payload
-        payload = {
-            "model": MODEL,
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": request.message}
-            ],
-            "tools": TOOLS,
-            "tool_choice": "auto",
-            "stream": True,
-            "max_tokens": 1500
-        }
-        
+        logger.info("Processing message: %s...", request.message[:100])
+
+        payload = build_chat_payload(request.message)
+
         if request.stream:
             # Return streaming response using Server-Sent Events
             return StreamingResponse(
@@ -421,27 +297,23 @@ async def chat(request: ChatRequest):
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
                     "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Headers": "Cache-Control"
-                }
+                    "Access-Control-Allow-Headers": "Cache-Control",
+                },
             )
         else:
             # Return non-streaming JSON response
             response_content, citations = await get_non_streaming_response(payload)
-            
-            # Remove duplicates from citations while preserving order
-            unique_citations = []
-            for citation in citations:
-                if citation not in unique_citations:
-                    unique_citations.append(citation)
-            
+            unique_citations = deduplicate_citations(citations)
+
             return {
                 "response": response_content,
-                "citations": unique_citations if unique_citations else None
+                "citations": unique_citations if unique_citations else None,
             }
-        
+
     except Exception as e:
-        print(f"[ERROR] Chat handling failed: {e}")
+        logger.error("Chat handling failed: %s", e)
         raise HTTPException(status_code=500, detail=f"Request failed: {e}")
+
 
 if __name__ == "__main__":
     print("🚀 Starting Kubeflow Docs HTTP API Server")
@@ -449,9 +321,5 @@ if __name__ == "__main__":
     print(f"   LLM Service: {KSERVE_URL}")
     print(f"   Milvus: {MILVUS_HOST}:{MILVUS_PORT}")
     print(f"   Collection: {MILVUS_COLLECTION}")
-    
-    uvicorn.run(
-        app, 
-        host="0.0.0.0", 
-        port=PORT
-    )
+
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/server-https/requirements.txt
+++ b/server-https/requirements.txt
@@ -6,4 +6,3 @@ sentence-transformers
 pymilvus
 torch --extra-index-url https://download.pytorch.org/whl/cpu
 numpy
-beautifulsoup4

--- a/server-https/requirements.txt
+++ b/server-https/requirements.txt
@@ -6,3 +6,4 @@ sentence-transformers
 pymilvus
 torch --extra-index-url https://download.pytorch.org/whl/cpu
 numpy
+beautifulsoup4

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p $HF_HOME $SENTENCE_TRANSFORMERS_HOME $XDG_CACHE_HOME && \
 USER appuser
 
 # App
+COPY shared/ /app/shared/
 COPY app.py /app/
 
 EXPOSE 8000

--- a/server/app.py
+++ b/server/app.py
@@ -1,392 +1,285 @@
-import os
 import json
 import asyncio
-import httpx
+import logging
+import sys
+import os
+
 import websockets
 from websockets.server import serve
 from websockets.exceptions import ConnectionClosedError
-import logging
+
+# Add project root to path so shared module is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from shared.rag_core import (  # noqa: E402
+    KSERVE_URL,
+    MODEL,
+    MILVUS_HOST,
+    MILVUS_PORT,
+    MILVUS_COLLECTION,
+    PORT,
+    SYSTEM_PROMPT,
+    TOOLS,
+    execute_tool,
+    deduplicate_citations,
+    build_chat_payload,
+)
+
 from typing import Dict, Any, List
-from sentence_transformers import SentenceTransformer
-from pymilvus import connections, Collection
 
-# Config
-KSERVE_URL = os.getenv("KSERVE_URL", "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions")
-MODEL = os.getenv("MODEL", "llama3.1-8B")
-PORT = int(os.getenv("PORT", "8000"))
-
-# Milvus Config
-MILVUS_HOST = os.getenv("MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local")
-MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
-MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
-MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
-
-# System prompt
-SYSTEM_PROMPT = """
-You are the Kubeflow Docs Assistant.
-
-!!IMPORTANT!!
-- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
-- You should never output the raw tool call to the user.
-
-Your role
-- Always answer the user's question directly.
-- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
-- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
-
-Tool Use
-- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
-- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
-- When you do call the tool:
-  • Use one clear, focused query.  
-  • Summarize the result in your own words.  
-  • If no results are relevant, say “not found in the docs” and suggest refining the query.
-- Example usage:
-  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
-  - You should make a tool call to search the docs with a query "kubeflow setup".
-
-  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
-  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
-
-The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
-
-Routing
-- Greetings/small talk → respond briefly, no tool.  
-- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
-- Kubeflow-specific → answer and call the tool if documentation is needed.  
-
-Style
-- Be concise (2–5 sentences). Use bullet points or steps when helpful.
-- Provide examples only when asked.
-- Never invent features. If unsure, say so.
-- Reply in clean Markdown.
-"""
+logger = logging.getLogger(__name__)
 
 
-
-def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
-    """Execute a semantic search in Milvus and return structured JSON serializable results."""
-    try:
-        # Connect to Milvus
-        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
-        collection = Collection(MILVUS_COLLECTION)
-        collection.load()
-
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
-
-        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
-        results = collection.search(
-            data=[query_vec],
-            anns_field=MILVUS_VECTOR_FIELD,
-            param=search_params,
-            limit=int(top_k),
-            output_fields=["file_path", "content_text", "citation_url"],
-        )
-
-        hits = []
-        for hit in results[0]:
-            # similarity = 1 - distance for COSINE in Milvus
-            similarity = 1.0 - float(hit.distance)
-            entity = hit.entity
-            content_text = entity.get("content_text") or ""
-            if isinstance(content_text, str) and len(content_text) > 400:
-                content_text = content_text[:400] + "..."
-            hits.append({
-                "similarity": similarity,
-                "file_path": entity.get("file_path"),
-                "citation_url": entity.get("citation_url"),
-                "content_text": content_text,
-            })
-        return {"results": hits}
-    except Exception as e:
-        print(f"[ERROR] Milvus search failed: {e}")
-        return {"results": []}
-    finally:
-        try:
-            connections.disconnect(alias="default")
-        except Exception:
-            pass
-TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "search_kubeflow_docs",
-            "description": (
-                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
-                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
-                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
-                        "minLength": 1
-                    },
-                    "top_k": {
-                        "type": "integer",
-                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
-                        "default": 5,
-                        "minimum": 1,
-                        "maximum": 10
-                    }
-                },
-                "required": ["query"],
-                "additionalProperties": False
-            }
-        }
-    }
-]
-
-
-async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
-    """Execute a tool call and return the result and citations"""
-    try:
-        function_name = tool_call.get("function", {}).get("name")
-        arguments = json.loads(tool_call.get("function", {}).get("arguments", "{}"))
-        
-        if function_name == "search_kubeflow_docs":
-            query = arguments.get("query", "")
-            top_k = arguments.get("top_k", 5)
-            
-            print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, top_k)
-            
-            # Collect citations
-            citations = []
-            formatted_results = []
-            
-            for hit in result.get("results", []):
-                citation_url = hit.get('citation_url', '')
-                if citation_url and citation_url not in citations:
-                    citations.append(citation_url)
-                
-                formatted_results.append(
-                    f"File: {hit.get('file_path', 'Unknown')}\n"
-                    f"Content: {hit.get('content_text', '')}\n"
-                    f"URL: {citation_url}\n"
-                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
-                )
-            
-            formatted_text = "\n".join(formatted_results) if formatted_results else "No relevant results found."
-            return formatted_text, citations
-        
-        return f"Unknown tool: {function_name}", []
-        
-    except Exception as e:
-        print(f"[ERROR] Tool execution failed: {e}")
-        return f"Tool execution failed: {e}", []
-
-async def stream_llm_response(payload: Dict[str, Any], websocket, citations_collector: List[str] = None) -> None:
+async def stream_llm_response(
+    payload: Dict[str, Any],
+    websocket,
+    citations_collector: List[str] = None,
+) -> None:
     """Stream response from LLM to websocket, handling tool calls"""
     if citations_collector is None:
         citations_collector = []
     try:
+        import httpx
+
         async with httpx.AsyncClient(timeout=120) as client:
             async with client.stream("POST", KSERVE_URL, json=payload) as response:
                 if response.status_code != 200:
                     error_msg = f"LLM service error: HTTP {response.status_code}"
-                    print(f"[ERROR] {error_msg}")
-                    await websocket.send(json.dumps({"type": "error", "content": error_msg}))
+                    logger.error(error_msg)
+                    await websocket.send(
+                        json.dumps({"type": "error", "content": error_msg})
+                    )
                     return
-                
+
                 # Buffer for accumulating tool calls
                 tool_calls_buffer = {}
-                
+
                 async for line in response.aiter_lines():
                     if not line.startswith("data: "):
                         continue
-                    
+
                     data = line[6:]  # Remove "data: " prefix
                     if data == "[DONE]":
                         break
-                    
+
                     try:
                         chunk = json.loads(data)
                         choices = chunk.get("choices", [])
                         if not choices:
                             continue
-                            
+
                         delta = choices[0].get("delta", {})
                         finish_reason = choices[0].get("finish_reason")
-                        
+
                         # Handle tool calls in streaming
                         if "tool_calls" in delta:
                             tool_calls = delta["tool_calls"]
                             for tool_call in tool_calls:
                                 index = tool_call.get("index", 0)
-                                
+
                                 # Initialize tool call buffer if needed
                                 if index not in tool_calls_buffer:
                                     tool_calls_buffer[index] = {
                                         "id": tool_call.get("id", ""),
                                         "type": tool_call.get("type", "function"),
                                         "function": {
-                                            "name": tool_call.get("function", {}).get("name", ""),
-                                            "arguments": ""
-                                        }
+                                            "name": tool_call.get("function", {}).get(
+                                                "name", ""
+                                            ),
+                                            "arguments": "",
+                                        },
                                     }
-                                
+
                                 # Update tool call data
                                 if tool_call.get("id"):
                                     tool_calls_buffer[index]["id"] = tool_call["id"]
                                 if tool_call.get("type"):
                                     tool_calls_buffer[index]["type"] = tool_call["type"]
-                                
+
                                 function_data = tool_call.get("function", {})
                                 if function_data.get("name"):
-                                    tool_calls_buffer[index]["function"]["name"] = function_data["name"]
+                                    tool_calls_buffer[index]["function"]["name"] = (
+                                        function_data["name"]
+                                    )
                                 if "arguments" in function_data:
-                                    tool_calls_buffer[index]["function"]["arguments"] += function_data["arguments"]
-                        
+                                    tool_calls_buffer[index]["function"][
+                                        "arguments"
+                                    ] += function_data["arguments"]
+
                         # Handle regular content
                         elif "content" in delta and delta["content"]:
-                            await websocket.send(json.dumps({
-                                "type": "content", 
-                                "content": delta["content"]
-                            }))
-                        
+                            await websocket.send(
+                                json.dumps(
+                                    {"type": "content", "content": delta["content"]}
+                                )
+                            )
+
                         # Handle finish reason - execute tools if needed
                         if finish_reason == "tool_calls":
-                            print(f"[TOOL] Finish reason: tool_calls, executing {len(tool_calls_buffer)} tools")
-                            
+                            logger.info(
+                                "Finish reason: tool_calls, executing %d tools",
+                                len(tool_calls_buffer),
+                            )
+
                             # Execute all accumulated tool calls
                             for tool_call in tool_calls_buffer.values():
-                                if tool_call["function"]["name"] and tool_call["function"]["arguments"]:
+                                if (
+                                    tool_call["function"]["name"]
+                                    and tool_call["function"]["arguments"]
+                                ):
                                     try:
-                                        print(f"[TOOL] Executing: {tool_call['function']['name']}")
-                                        print(f"[TOOL] Arguments: {tool_call['function']['arguments']}")
-                                        
-                                        result, tool_citations = await execute_tool(tool_call)
-                                        
+                                        logger.info(
+                                            "Executing: %s",
+                                            tool_call["function"]["name"],
+                                        )
+
+                                        result, tool_citations = await execute_tool(
+                                            tool_call
+                                        )
+
                                         # Collect citations
                                         citations_collector.extend(tool_citations)
-                                        
+
                                         # Send tool execution result to client
-                                        await websocket.send(json.dumps({
-                                            "type": "tool_result",
-                                            "tool_name": tool_call["function"]["name"],
-                                            "content": result
-                                        }))
-                                        
+                                        await websocket.send(
+                                            json.dumps(
+                                                {
+                                                    "type": "tool_result",
+                                                    "tool_name": tool_call["function"][
+                                                        "name"
+                                                    ],
+                                                    "content": result,
+                                                }
+                                            )
+                                        )
+
                                         # Make follow-up request with tool results
-                                        await handle_tool_follow_up(payload, tool_call, result, websocket, citations_collector)
-                                        
+                                        await handle_tool_follow_up(
+                                            payload,
+                                            tool_call,
+                                            result,
+                                            websocket,
+                                            citations_collector,
+                                        )
+
                                     except Exception as e:
-                                        print(f"[ERROR] Tool execution error: {e}")
-                                        await websocket.send(json.dumps({
-                                            "type": "error",
-                                            "content": f"Tool execution failed: {e}"
-                                        }))
-                            
+                                        logger.error("Tool execution error: %s", e)
+                                        await websocket.send(
+                                            json.dumps(
+                                                {
+                                                    "type": "error",
+                                                    "content": f"Tool execution failed: {e}",
+                                                }
+                                            )
+                                        )
+
                             tool_calls_buffer.clear()
                             break  # Tool execution complete, exit streaming loop
-                            
-                    except json.JSONDecodeError as e:
-                        print(f"[ERROR] JSON decode error: {e}, line: {line}")
-                        continue
-                        
-    except Exception as e:
-        print(f"[ERROR] Streaming failed: {e}")
-        await websocket.send(json.dumps({"type": "error", "content": f"Streaming failed: {e}"}))
 
-async def handle_tool_follow_up(original_payload: Dict[str, Any], tool_call: Dict[str, Any], tool_result: str, websocket, citations_collector: List[str] = None) -> None:
+                    except json.JSONDecodeError as e:
+                        logger.error("JSON decode error: %s, line: %s", e, line)
+                        continue
+
+    except Exception as e:
+        logger.error("Streaming failed: %s", e)
+        await websocket.send(
+            json.dumps({"type": "error", "content": f"Streaming failed: {e}"})
+        )
+
+
+async def handle_tool_follow_up(
+    original_payload: Dict[str, Any],
+    tool_call: Dict[str, Any],
+    tool_result: str,
+    websocket,
+    citations_collector: List[str] = None,
+) -> None:
     """Handle follow-up request after tool execution"""
     if citations_collector is None:
         citations_collector = []
     try:
-        print("[TOOL] Handling follow-up request with tool results")
-        
+        logger.info("Handling follow-up request with tool results")
+
         # Create messages with tool call and result
         messages = original_payload["messages"].copy()
-        
+
         # Add assistant's tool call message
-        messages.append({
-            "role": "assistant",
-            "tool_calls": [tool_call]
-        })
-        
+        messages.append({"role": "assistant", "tool_calls": [tool_call]})
+
         # Add tool result message
-        messages.append({
-            "role": "tool",
-            "tool_call_id": tool_call["id"],
-            "content": tool_result
-        })
-        
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call["id"],
+                "content": tool_result,
+            }
+        )
+
         # Create follow-up payload - remove tools to get final response
         follow_up_payload = {
             "model": original_payload["model"],
             "messages": messages,
             "stream": True,
-            "max_tokens": 1000
+            "max_tokens": 1000,
         }
-        
+
         # Stream the follow-up response
         await stream_llm_response(follow_up_payload, websocket, citations_collector)
-        
+
     except Exception as e:
-        print(f"[ERROR] Tool follow-up failed: {e}")
-        await websocket.send(json.dumps({"type": "error", "content": f"Tool follow-up failed: {e}"}))
+        logger.error("Tool follow-up failed: %s", e)
+        await websocket.send(
+            json.dumps(
+                {"type": "error", "content": f"Tool follow-up failed: {e}"}
+            )
+        )
+
 
 async def handle_chat(message: str, websocket) -> None:
     """Handle chat with tool calling support"""
     try:
-        print(f"[CHAT] Processing message: {message[:100]}...")
-        
-        # Create initial payload
-        payload = {
-            "model": MODEL,
-            "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": message}
-            ],
-            "tools": TOOLS,
-            "tool_choice": "auto",
-            "stream": True,
-            "max_tokens": 1500
-        }
-        
+        logger.info("Processing message: %s...", message[:100])
+
+        payload = build_chat_payload(message)
+
         # Collect citations throughout the conversation
-        citations_collector = []
-        
+        citations_collector: List[str] = []
+
         # Start streaming response
         await stream_llm_response(payload, websocket, citations_collector)
-        
+
         # Send citations if any were collected
         if citations_collector:
-            # Remove duplicates while preserving order
-            unique_citations = []
-            for citation in citations_collector:
-                if citation not in unique_citations:
-                    unique_citations.append(citation)
-            
-            await websocket.send(json.dumps({
-                "type": "citations", 
-                "citations": unique_citations
-            }))
-        
+            unique_citations = deduplicate_citations(citations_collector)
+            await websocket.send(
+                json.dumps({"type": "citations", "citations": unique_citations})
+            )
+
         # Send completion signal
         await websocket.send(json.dumps({"type": "done"}))
-        
+
     except Exception as e:
-        print(f"[ERROR] Chat handling failed: {e}")
-        await websocket.send(json.dumps({"type": "error", "content": f"Request failed: {e}"}))
+        logger.error("Chat handling failed: %s", e)
+        await websocket.send(
+            json.dumps({"type": "error", "content": f"Request failed: {e}"})
+        )
+
 
 async def handle_websocket(websocket, path):
     """Handle WebSocket connections"""
-    print(f"[WS] New connection from {websocket.remote_address}")
-    
+    logger.info("New connection from %s", websocket.remote_address)
+
     try:
         # Send welcome message
-        await websocket.send(json.dumps({
-            "type": "system",
-            "content": "Connected to Kubeflow Documentation Assistant"
-        }))
-        
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "system",
+                    "content": "Connected to Kubeflow Documentation Assistant",
+                }
+            )
+        )
+
         async for message in websocket:
             try:
                 # Ensure we always deal with string, not bytes
@@ -402,26 +295,32 @@ async def handle_websocket(websocket, path):
                     # Treat as plain text message
                     pass
 
-                print(f"[WS] Received: {message[:100]}...")
+                logger.info("Received: %s...", message[:100])
                 await handle_chat(message, websocket)
-                
+
             except Exception as e:
-                print(f"[ERROR] Message processing error: {e}")
-                await websocket.send(json.dumps({
-                    "type": "error", 
-                    "content": f"Message processing failed: {e}"
-                }))
-                
+                logger.error("Message processing error: %s", e)
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "content": f"Message processing failed: {e}",
+                        }
+                    )
+                )
+
     except ConnectionClosedError:
-        print("[WS] Connection closed")
+        logger.info("Connection closed")
     except Exception as e:
-        print(f"[ERROR] WebSocket error: {e}")
+        logger.error("WebSocket error: %s", e)
+
 
 async def health_check(path, request_headers):
     """Handle HTTP health checks"""
     if path == "/health":
         return 200, [("Content-Type", "text/plain")], b"OK"
     return None
+
 
 async def main():
     """Start the WebSocket server"""
@@ -430,25 +329,27 @@ async def main():
     print(f"   LLM Service: {KSERVE_URL}")
     print(f"   Milvus: {MILVUS_HOST}:{MILVUS_PORT}")
     print(f"   Collection: {MILVUS_COLLECTION}")
-    
+
     # Configure logging
+    logging.basicConfig(level=logging.INFO)
     logging.getLogger("websockets").setLevel(logging.WARNING)
-    
+
     # Start server
     async with serve(
-        handle_websocket, 
-        "0.0.0.0", 
+        handle_websocket,
+        "0.0.0.0",
         PORT,
         process_request=health_check,
         ping_interval=30,
-        ping_timeout=10
+        ping_timeout=10,
     ):
         print("✅ WebSocket server is running...")
         print(f"   WebSocket: ws://localhost:{PORT}")
         print(f"   Health: http://localhost:{PORT}/health")
-        
+
         # Keep server running
         await asyncio.Future()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/server/app.py
+++ b/server/app.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import sys
 import os
+import httpx
 
 import websockets
 from websockets.server import serve
@@ -39,7 +40,6 @@ async def stream_llm_response(
     if citations_collector is None:
         citations_collector = []
     try:
-        import httpx
 
         async with httpx.AsyncClient(timeout=120) as client:
             async with client.stream("POST", KSERVE_URL, json=payload) as response:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,4 +11,3 @@ torch --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Essential only
 numpy
-beautifulsoup4

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,3 +11,4 @@ torch --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Essential only
 numpy
+beautifulsoup4

--- a/shared/rag_core.py
+++ b/shared/rag_core.py
@@ -12,6 +12,8 @@ from typing import Dict, Any, List, Tuple
 
 from sentence_transformers import SentenceTransformer
 from pymilvus import connections, Collection
+import httpx
+from bs4 import BeautifulSoup
 
 # ---------------------------------------------------------------------------
 # Configuration (environment-driven with sensible defaults)

--- a/shared/rag_core.py
+++ b/shared/rag_core.py
@@ -8,12 +8,10 @@ functions used by both the WebSocket and HTTPS API servers.
 import os
 import json
 import logging
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Set, Tuple
 
 from sentence_transformers import SentenceTransformer
 from pymilvus import connections, Collection
-import httpx
-from bs4 import BeautifulSoup
 
 # ---------------------------------------------------------------------------
 # Configuration (environment-driven with sensible defaults)
@@ -221,7 +219,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> Tuple[str, List[str]]:
 
 def deduplicate_citations(citations: List[str]) -> List[str]:
     """Remove duplicate citations while preserving order."""
-    seen: set[str] = set()
+    seen: Set[str] = set()
     unique: List[str] = []
     for citation in citations:
         if citation not in seen:

--- a/shared/rag_core.py
+++ b/shared/rag_core.py
@@ -1,0 +1,250 @@
+"""
+Shared RAG utilities for the Kubeflow Documentation AI Assistant.
+
+This module contains shared configuration, prompts, tools, and utility
+functions used by both the WebSocket and HTTPS API servers.
+"""
+
+import os
+import json
+import logging
+from typing import Dict, Any, List, Tuple
+
+from sentence_transformers import SentenceTransformer
+from pymilvus import connections, Collection
+
+# ---------------------------------------------------------------------------
+# Configuration (environment-driven with sensible defaults)
+# ---------------------------------------------------------------------------
+
+KSERVE_URL = os.getenv(
+    "KSERVE_URL",
+    "http://llama.docs-agent.svc.cluster.local/openai/v1/chat/completions",
+)
+MODEL = os.getenv("MODEL", "llama3.1-8B")
+PORT = int(os.getenv("PORT", "8000"))
+
+# Milvus
+MILVUS_HOST = os.getenv(
+    "MILVUS_HOST", "my-release-milvus.docs-agent.svc.cluster.local"
+)
+MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
+MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
+EMBEDDING_MODEL = os.getenv(
+    "EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2"
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """
+You are the Kubeflow Docs Assistant.
+
+!!IMPORTANT!!
+- You should not use the tool calls directly from the user's input. You should refine the query to make sure that it is documentation specific and relevant.
+- You should never output the raw tool call to the user.
+
+Your role
+- Always answer the user's question directly.
+- If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
+- If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
+
+Tool Use
+- Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
+- Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
+- When you do call the tool:
+  • Use one clear, focused query.  
+  • Summarize the result in your own words.  
+  • If no results are relevant, say "not found in the docs" and suggest refining the query.
+- Example usage:
+  - User: "What is Kubeflow and how to setup kubeflow on my local machine"
+  - You should make a tool call to search the docs with a query "kubeflow setup".
+
+  - User: "What is the Kubeflow Pipelines and how can i make a quick kubeflow pipeline"
+  - You should make a tool call to search the docs with a query "kubeflow pipeline setup".
+
+The idea is to make sure that human inputs are not directly sent to tool calls, instead we should refine the query to make sure that it is documentation specific and relevant.
+
+Routing
+- Greetings/small talk → respond briefly, no tool.  
+- Out-of-scope (sports, unrelated topics) → politely say you only help with Kubeflow.  
+- Kubeflow-specific → answer and call the tool if documentation is needed.  
+
+Style
+- Be concise (2–5 sentences). Use bullet points or steps when helpful.
+- Provide examples only when asked.
+- Never invent features. If unsure, say so.
+- Reply in clean Markdown.
+"""
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_kubeflow_docs",
+            "description": (
+                "Search the official Kubeflow docs when the user asks Kubeflow-specific questions "
+                "about Pipelines, KServe, Notebooks/Jupyter, Katib, or the SDK/CLI/APIs.\n"
+                "Call ONLY for Kubeflow features, setup, usage, errors, or version differences that need citations.\n"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Short, focused search string (e.g., 'KServe inferenceService canary', 'Pipelines v2 disable cache').",
+                        "minLength": 1,
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Number of hits to retrieve (the assistant will read up to this many).",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 10,
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+# ---------------------------------------------------------------------------
+# Milvus semantic search
+# ---------------------------------------------------------------------------
+
+
+def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
+    """Execute a semantic search in Milvus and return structured JSON-serializable results."""
+    try:
+        connections.connect(alias="default", host=MILVUS_HOST, port=MILVUS_PORT)
+        collection = Collection(MILVUS_COLLECTION)
+        collection.load()
+
+        encoder = SentenceTransformer(EMBEDDING_MODEL)
+        query_vec = encoder.encode(query).tolist()
+
+        search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
+        results = collection.search(
+            data=[query_vec],
+            anns_field=MILVUS_VECTOR_FIELD,
+            param=search_params,
+            limit=int(top_k),
+            output_fields=["file_path", "content_text", "citation_url"],
+        )
+
+        hits = []
+        for hit in results[0]:
+            similarity = 1.0 - float(hit.distance)
+            entity = hit.entity
+            content_text = entity.get("content_text") or ""
+            if isinstance(content_text, str) and len(content_text) > 400:
+                content_text = content_text[:400] + "..."
+            hits.append(
+                {
+                    "similarity": similarity,
+                    "file_path": entity.get("file_path"),
+                    "citation_url": entity.get("citation_url"),
+                    "content_text": content_text,
+                }
+            )
+        return {"results": hits}
+    except Exception as e:
+        logger.error("Milvus search failed: %s", e)
+        return {"results": []}
+    finally:
+        try:
+            connections.disconnect(alias="default")
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Tool execution
+# ---------------------------------------------------------------------------
+
+
+async def execute_tool(tool_call: Dict[str, Any]) -> Tuple[str, List[str]]:
+    """Execute a tool call and return ``(result_text, citations)``."""
+    try:
+        function_name = tool_call.get("function", {}).get("name")
+        arguments = json.loads(
+            tool_call.get("function", {}).get("arguments", "{}")
+        )
+
+        if function_name == "search_kubeflow_docs":
+            query = arguments.get("query", "")
+            top_k = arguments.get("top_k", 5)
+
+            logger.info("Executing Milvus search for: '%s' (top_k=%s)", query, top_k)
+            result = milvus_search(query, top_k)
+
+            citations: List[str] = []
+            formatted_results: List[str] = []
+
+            for hit in result.get("results", []):
+                citation_url = hit.get("citation_url", "")
+                if citation_url and citation_url not in citations:
+                    citations.append(citation_url)
+
+                formatted_results.append(
+                    f"File: {hit.get('file_path', 'Unknown')}\n"
+                    f"Content: {hit.get('content_text', '')}\n"
+                    f"URL: {citation_url}\n"
+                    f"Similarity: {hit.get('similarity', 0):.3f}\n"
+                )
+
+            formatted_text = (
+                "\n".join(formatted_results)
+                if formatted_results
+                else "No relevant results found."
+            )
+            return formatted_text, citations
+
+        return f"Unknown tool: {function_name}", []
+
+    except Exception as e:
+        logger.error("Tool execution failed: %s", e)
+        return f"Tool execution failed: {e}", []
+
+
+def deduplicate_citations(citations: List[str]) -> List[str]:
+    """Remove duplicate citations while preserving order."""
+    seen: set[str] = set()
+    unique: List[str] = []
+    for citation in citations:
+        if citation not in seen:
+            seen.add(citation)
+            unique.append(citation)
+    return unique
+
+
+def build_chat_payload(
+    message: str,
+    *,
+    include_tools: bool = True,
+    max_tokens: int = 1500,
+) -> Dict[str, Any]:
+    """Build the initial chat payload for the LLM."""
+    payload: Dict[str, Any] = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": message},
+        ],
+        "stream": True,
+        "max_tokens": max_tokens,
+    }
+    if include_tools:
+        payload["tools"] = TOOLS
+        payload["tool_choice"] = "auto"
+    return payload

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,7 +26,7 @@ docs-agent stack on **Oracle Cloud Infrastructure (OCI)**.
 | `oke`        | OKE cluster with CPU + GPU node pools            |
 | `milvus`     | Milvus vector DB via Helm chart                  |
 | `kserve`     | KServe + Knative + cert-manager for LLM serving  |
-| `docs-agent` | docs-agent Deployment, Service, Ingress          |
+| `docs-agent` | docs-agent Deployment + ClusterIP Services       |
 
 ## Quick start
 
@@ -38,6 +38,17 @@ terraform init
 terraform plan
 terraform apply
 ```
+
+## Data ingestion
+
+After the infrastructure is provisioned, populate the Milvus vector
+database by running the KFP pipelines:
+
+1. **Kubeflow docs** — use the existing `pipelines/kubeflow-pipeline.py`
+2. **Platform architecture** — use `pipelines/platform-architecture-pipeline.py`
+
+Both pipelines can be compiled locally and submitted to a KFP-enabled
+cluster, or run manually with a port-forward to the Milvus service.
 
 ## Prerequisites
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,47 @@
+# Kubeflow Docs-Agent — OCI Deployment (Terraform)
+
+This directory contains Terraform modules for deploying the Kubeflow
+docs-agent stack on **Oracle Cloud Infrastructure (OCI)**.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                     OCI Tenancy                      │
+│  ┌───────────────────────────────────────────────┐  │
+│  │            OKE Cluster (Kubernetes)            │  │
+│  │  ┌─────────┐ ┌──────────┐ ┌───────────────┐  │  │
+│  │  │  Milvus │ │  KServe  │ │  docs-agent   │  │  │
+│  │  │ (vector │ │ (LLM     │ │ (WebSocket +  │  │  │
+│  │  │   DB)   │ │  serving)│ │  HTTPS API)   │  │  │
+│  │  └─────────┘ └──────────┘ └───────────────┘  │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+## Modules
+
+| Module       | Description                                      |
+|------------- |--------------------------------------------------|
+| `oke`        | OKE cluster with CPU + GPU node pools            |
+| `milvus`     | Milvus vector DB via Helm chart                  |
+| `kserve`     | KServe + Knative + cert-manager for LLM serving  |
+| `docs-agent` | docs-agent Deployment, Service, Ingress          |
+
+## Quick start
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your OCI credentials
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## Prerequisites
+
+- Terraform >= 1.5
+- OCI CLI configured (`oci setup config`)
+- An OCI compartment with sufficient quotas (OKE, GPU shapes)
+- A container registry with the docs-agent image built and pushed

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,119 @@
+# ---------------------------------------------------------------------------
+# Kubeflow Docs-Agent — OCI Terraform Root Module
+# ---------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.11"
+    }
+  }
+
+  # Uncomment to use OCI Object Storage as remote backend:
+  # backend "s3" {
+  #   bucket   = "docs-agent-tfstate"
+  #   key      = "terraform.tfstate"
+  #   region   = "us-ashburn-1"
+  #   endpoint = "https://<namespace>.compat.objectstorage.<region>.oraclecloud.com"
+  # }
+}
+
+# ---------------------------------------------------------------------------
+# Provider configuration
+# ---------------------------------------------------------------------------
+
+provider "oci" {
+  tenancy_ocid = var.tenancy_ocid
+  user_ocid    = var.user_ocid
+  fingerprint  = var.fingerprint
+  private_key  = var.private_key
+  region       = var.region
+}
+
+provider "kubernetes" {
+  host                   = module.oke.cluster_endpoint
+  cluster_ca_certificate = module.oke.cluster_ca_certificate
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "oci"
+    args = [
+      "ce", "cluster", "generate-token",
+      "--cluster-id", module.oke.cluster_id,
+      "--region", var.region,
+    ]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.oke.cluster_endpoint
+    cluster_ca_certificate = module.oke.cluster_ca_certificate
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "oci"
+      args = [
+        "ce", "cluster", "generate-token",
+        "--cluster-id", module.oke.cluster_id,
+        "--region", var.region,
+      ]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Modules
+# ---------------------------------------------------------------------------
+
+module "oke" {
+  source = "./modules/oke"
+
+  compartment_id    = var.compartment_id
+  cluster_name      = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+  vcn_cidr          = var.vcn_cidr
+  region            = var.region
+
+  # Node pools
+  cpu_node_shape    = var.cpu_node_shape
+  cpu_node_count    = var.cpu_node_count
+  gpu_node_shape    = var.gpu_node_shape
+  gpu_node_count    = var.gpu_node_count
+}
+
+module "milvus" {
+  source     = "./modules/milvus"
+  depends_on = [module.oke]
+
+  namespace        = var.namespace
+  milvus_storage   = var.milvus_storage_gb
+}
+
+module "kserve" {
+  source     = "./modules/kserve"
+  depends_on = [module.oke]
+
+  namespace = var.namespace
+}
+
+module "docs_agent" {
+  source     = "./modules/docs-agent"
+  depends_on = [module.milvus, module.kserve]
+
+  namespace    = var.namespace
+  image        = var.docs_agent_image
+  replicas     = var.docs_agent_replicas
+  milvus_host  = module.milvus.service_host
+  milvus_port  = module.milvus.service_port
+  kserve_url   = module.kserve.inference_url
+}

--- a/terraform/modules/docs-agent/main.tf
+++ b/terraform/modules/docs-agent/main.tf
@@ -1,6 +1,10 @@
 # ---------------------------------------------------------------------------
 # Docs-Agent Module — Deploy the WebSocket + HTTPS API servers
 # ---------------------------------------------------------------------------
+#
+# The container image should be built from the repository root so that
+# both server/ and shared/ directories are in the build context:
+#   docker build -f server/Dockerfile -t docs-agent:latest .
 
 terraform {
   required_providers {
@@ -106,6 +110,14 @@ resource "kubernetes_deployment" "ws_server" {
             initial_delay_seconds = 10
             period_seconds        = 30
           }
+
+          readiness_probe {
+            tcp_socket {
+              port = 8765
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
         }
       }
     }
@@ -197,6 +209,15 @@ resource "kubernetes_deployment" "https_server" {
             }
             initial_delay_seconds = 10
             period_seconds        = 30
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/health"
+              port = 8000
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
           }
         }
       }

--- a/terraform/modules/docs-agent/main.tf
+++ b/terraform/modules/docs-agent/main.tf
@@ -1,0 +1,229 @@
+# ---------------------------------------------------------------------------
+# Docs-Agent Module — Deploy the WebSocket + HTTPS API servers
+# ---------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23"
+    }
+  }
+}
+
+variable "namespace" {
+  type    = string
+  default = "docs-agent"
+}
+
+variable "image" {
+  type    = string
+  default = "ghcr.io/kubeflow/docs-agent:latest"
+}
+
+variable "replicas" {
+  type    = number
+  default = 2
+}
+
+variable "milvus_host" {
+  type = string
+}
+
+variable "milvus_port" {
+  type    = string
+  default = "19530"
+}
+
+variable "kserve_url" {
+  type = string
+}
+
+# -- WebSocket server (port 8765) ------------------------------------------
+
+resource "kubernetes_deployment" "ws_server" {
+  metadata {
+    name      = "docs-agent-ws"
+    namespace = var.namespace
+    labels    = { app = "docs-agent-ws" }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = { app = "docs-agent-ws" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "docs-agent-ws" }
+      }
+
+      spec {
+        container {
+          name  = "ws-server"
+          image = var.image
+
+          command = ["python", "server/app.py"]
+
+          port {
+            container_port = 8765
+          }
+
+          env {
+            name  = "MILVUS_HOST"
+            value = var.milvus_host
+          }
+          env {
+            name  = "MILVUS_PORT"
+            value = var.milvus_port
+          }
+          env {
+            name  = "KSERVE_URL"
+            value = var.kserve_url
+          }
+          env {
+            name  = "PORT"
+            value = "8765"
+          }
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "512Mi"
+            }
+            limits = {
+              cpu    = "1"
+              memory = "2Gi"
+            }
+          }
+
+          liveness_probe {
+            tcp_socket {
+              port = 8765
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 30
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "ws_server" {
+  metadata {
+    name      = "docs-agent-ws"
+    namespace = var.namespace
+  }
+
+  spec {
+    selector = { app = "docs-agent-ws" }
+
+    port {
+      port        = 8765
+      target_port = 8765
+    }
+
+    type = "ClusterIP"
+  }
+}
+
+# -- HTTPS server (port 8000) ---------------------------------------------
+
+resource "kubernetes_deployment" "https_server" {
+  metadata {
+    name      = "docs-agent-https"
+    namespace = var.namespace
+    labels    = { app = "docs-agent-https" }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = { app = "docs-agent-https" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "docs-agent-https" }
+      }
+
+      spec {
+        container {
+          name  = "https-server"
+          image = var.image
+
+          command = ["python", "server-https/app.py"]
+
+          port {
+            container_port = 8000
+          }
+
+          env {
+            name  = "MILVUS_HOST"
+            value = var.milvus_host
+          }
+          env {
+            name  = "MILVUS_PORT"
+            value = var.milvus_port
+          }
+          env {
+            name  = "KSERVE_URL"
+            value = var.kserve_url
+          }
+          env {
+            name  = "PORT"
+            value = "8000"
+          }
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "512Mi"
+            }
+            limits = {
+              cpu    = "1"
+              memory = "2Gi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/health"
+              port = 8000
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 30
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "https_server" {
+  metadata {
+    name      = "docs-agent-https"
+    namespace = var.namespace
+  }
+
+  spec {
+    selector = { app = "docs-agent-https" }
+
+    port {
+      port        = 8000
+      target_port = 8000
+    }
+
+    type = "ClusterIP"
+  }
+}
+
+# -- Outputs ---------------------------------------------------------------
+
+output "service_url" {
+  value = "http://docs-agent-https.${var.namespace}.svc.cluster.local:8000"
+}

--- a/terraform/modules/kserve/main.tf
+++ b/terraform/modules/kserve/main.tf
@@ -1,0 +1,75 @@
+# ---------------------------------------------------------------------------
+# KServe Module — Install KServe + dependencies for LLM serving
+# ---------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.11"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23"
+    }
+  }
+}
+
+variable "namespace" {
+  type    = string
+  default = "docs-agent"
+}
+
+# -- cert-manager (required by KServe) ------------------------------------
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = "v1.13.3"
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}
+
+# -- Knative Serving (required by KServe for scale-to-zero) ----------------
+
+resource "helm_release" "knative_serving" {
+  name             = "knative-serving"
+  namespace        = "knative-serving"
+  create_namespace = true
+  repository       = "https://knative.github.io/operator"
+  chart            = "knative-serving"
+  version          = "1.12.0"
+
+  depends_on = [helm_release.cert_manager]
+}
+
+# -- KServe ----------------------------------------------------------------
+
+resource "helm_release" "kserve" {
+  name             = "kserve"
+  namespace        = "kserve"
+  create_namespace = true
+  repository       = "https://kserve.github.io/kserve"
+  chart            = "kserve"
+  version          = "0.12.0"
+
+  set {
+    name  = "kserve.controller.deploymentMode"
+    value = "Serverless"
+  }
+
+  depends_on = [helm_release.knative_serving]
+}
+
+# -- Outputs ---------------------------------------------------------------
+
+output "inference_url" {
+  description = "Default KServe inference endpoint pattern."
+  value       = "http://llama.${var.namespace}.svc.cluster.local/openai/v1/chat/completions"
+}

--- a/terraform/modules/milvus/main.tf
+++ b/terraform/modules/milvus/main.tf
@@ -1,0 +1,85 @@
+# ---------------------------------------------------------------------------
+# Milvus Module — Deploy Milvus via Helm
+# ---------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.11"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23"
+    }
+  }
+}
+
+variable "namespace" {
+  type    = string
+  default = "docs-agent"
+}
+
+variable "milvus_storage" {
+  description = "Storage size in GB for Milvus persistent volume."
+  type        = number
+  default     = 50
+}
+
+# -- Namespace --------------------------------------------------------------
+
+resource "kubernetes_namespace" "this" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+# -- Milvus Helm Release ---------------------------------------------------
+
+resource "helm_release" "milvus" {
+  name       = "milvus"
+  namespace  = kubernetes_namespace.this.metadata[0].name
+  repository = "https://zilliztech.github.io/milvus-helm"
+  chart      = "milvus"
+  version    = "4.1.26"
+
+  # Standalone mode (suitable for dev/small deployments)
+  set {
+    name  = "cluster.enabled"
+    value = "false"
+  }
+  set {
+    name  = "standalone.enabled"
+    value = "true"
+  }
+
+  # Persistence
+  set {
+    name  = "standalone.persistence.enabled"
+    value = "true"
+  }
+  set {
+    name  = "standalone.persistence.size"
+    value = "${var.milvus_storage}Gi"
+  }
+
+  # Expose on default port
+  set {
+    name  = "service.type"
+    value = "ClusterIP"
+  }
+  set {
+    name  = "service.port"
+    value = "19530"
+  }
+}
+
+# -- Outputs ---------------------------------------------------------------
+
+output "service_host" {
+  value = "milvus.${var.namespace}.svc.cluster.local"
+}
+
+output "service_port" {
+  value = "19530"
+}

--- a/terraform/modules/milvus/main.tf
+++ b/terraform/modules/milvus/main.tf
@@ -42,6 +42,8 @@ resource "helm_release" "milvus" {
   repository = "https://zilliztech.github.io/milvus-helm"
   chart      = "milvus"
   version    = "4.1.26"
+  wait       = true
+  timeout    = 600
 
   # Standalone mode (suitable for dev/small deployments)
   set {
@@ -76,8 +78,9 @@ resource "helm_release" "milvus" {
 
 # -- Outputs ---------------------------------------------------------------
 
+# The Helm chart creates a service named "<release>-milvus" by default.
 output "service_host" {
-  value = "milvus.${var.namespace}.svc.cluster.local"
+  value = "milvus-milvus.${var.namespace}.svc.cluster.local"
 }
 
 output "service_port" {

--- a/terraform/modules/oke/main.tf
+++ b/terraform/modules/oke/main.tf
@@ -1,0 +1,174 @@
+# ---------------------------------------------------------------------------
+# OKE Cluster Module — Oracle Kubernetes Engine
+# ---------------------------------------------------------------------------
+#
+# Creates a VCN, subnets, and an OKE cluster with CPU and optional GPU
+# node pools for running the docs-agent stack.
+
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# -- Variables --------------------------------------------------------------
+
+variable "compartment_id" {
+  type = string
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "docs-agent-cluster"
+}
+
+variable "kubernetes_version" {
+  type    = string
+  default = "v1.28.2"
+}
+
+variable "vcn_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "region" {
+  type = string
+}
+
+variable "cpu_node_shape" {
+  type    = string
+  default = "VM.Standard.E4.Flex"
+}
+
+variable "cpu_node_count" {
+  type    = number
+  default = 3
+}
+
+variable "gpu_node_shape" {
+  type    = string
+  default = "VM.GPU.A10.1"
+}
+
+variable "gpu_node_count" {
+  type    = number
+  default = 1
+}
+
+# -- VCN -------------------------------------------------------------------
+
+resource "oci_core_vcn" "this" {
+  compartment_id = var.compartment_id
+  display_name   = "${var.cluster_name}-vcn"
+  cidr_blocks    = [var.vcn_cidr]
+}
+
+resource "oci_core_subnet" "api" {
+  compartment_id = var.compartment_id
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "${var.cluster_name}-api-subnet"
+  cidr_block     = cidrsubnet(var.vcn_cidr, 8, 0)
+}
+
+resource "oci_core_subnet" "workers" {
+  compartment_id = var.compartment_id
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "${var.cluster_name}-worker-subnet"
+  cidr_block     = cidrsubnet(var.vcn_cidr, 8, 1)
+}
+
+resource "oci_core_subnet" "lb" {
+  compartment_id = var.compartment_id
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "${var.cluster_name}-lb-subnet"
+  cidr_block     = cidrsubnet(var.vcn_cidr, 8, 2)
+}
+
+# -- OKE Cluster -----------------------------------------------------------
+
+resource "oci_containerengine_cluster" "this" {
+  compartment_id     = var.compartment_id
+  kubernetes_version = var.kubernetes_version
+  name               = var.cluster_name
+  vcn_id             = oci_core_vcn.this.id
+
+  endpoint_config {
+    is_public_ip_enabled = true
+    subnet_id            = oci_core_subnet.api.id
+  }
+
+  options {
+    service_lb_subnet_ids = [oci_core_subnet.lb.id]
+  }
+}
+
+# -- CPU Node Pool ---------------------------------------------------------
+
+resource "oci_containerengine_node_pool" "cpu" {
+  compartment_id     = var.compartment_id
+  cluster_id         = oci_containerengine_cluster.this.id
+  kubernetes_version = var.kubernetes_version
+  name               = "${var.cluster_name}-cpu-pool"
+
+  node_shape = var.cpu_node_shape
+
+  node_shape_config {
+    ocpus         = 4
+    memory_in_gbs = 32
+  }
+
+  node_config_details {
+    size = var.cpu_node_count
+
+    placement_configs {
+      availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
+      subnet_id           = oci_core_subnet.workers.id
+    }
+  }
+}
+
+# -- GPU Node Pool (optional) ----------------------------------------------
+
+resource "oci_containerengine_node_pool" "gpu" {
+  count = var.gpu_node_count > 0 ? 1 : 0
+
+  compartment_id     = var.compartment_id
+  cluster_id         = oci_containerengine_cluster.this.id
+  kubernetes_version = var.kubernetes_version
+  name               = "${var.cluster_name}-gpu-pool"
+  node_shape         = var.gpu_node_shape
+
+  node_config_details {
+    size = var.gpu_node_count
+
+    placement_configs {
+      availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
+      subnet_id           = oci_core_subnet.workers.id
+    }
+  }
+}
+
+# -- Data sources ----------------------------------------------------------
+
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = var.compartment_id
+}
+
+# -- Outputs ---------------------------------------------------------------
+
+output "cluster_id" {
+  value = oci_containerengine_cluster.this.id
+}
+
+output "cluster_endpoint" {
+  value = oci_containerengine_cluster.this.endpoints[0].public_endpoint
+}
+
+output "cluster_ca_certificate" {
+  value     = base64decode(oci_containerengine_cluster.this.endpoints[0].public_endpoint)
+  sensitive = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------
+# Root module outputs
+# ---------------------------------------------------------------------------
+
+output "cluster_endpoint" {
+  description = "OKE cluster API server endpoint."
+  value       = module.oke.cluster_endpoint
+}
+
+output "milvus_endpoint" {
+  description = "Internal Milvus service endpoint."
+  value       = "${module.milvus.service_host}:${module.milvus.service_port}"
+}
+
+output "kserve_inference_url" {
+  description = "KServe InferenceService URL."
+  value       = module.kserve.inference_url
+}
+
+output "docs_agent_url" {
+  description = "Docs-agent service URL."
+  value       = module.docs_agent.service_url
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,29 @@
+# ---------------------------------------------------------------------------
+# Example variable values — copy to terraform.tfvars and fill in.
+# NEVER commit terraform.tfvars (it may contain secrets).
+# ---------------------------------------------------------------------------
+
+# -- OCI authentication (required) ----------------------------------------
+tenancy_ocid   = "ocid1.tenancy.oc1..aaaaaaaaexample"
+user_ocid      = "ocid1.user.oc1..aaaaaaaaexample"
+fingerprint    = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99"
+private_key    = "" # Use: file("~/.oci/oci_api_key.pem")
+region         = "us-ashburn-1"
+compartment_id = "ocid1.compartment.oc1..aaaaaaaaexample"
+
+# -- OKE cluster (optional overrides) -------------------------------------
+# cluster_name       = "docs-agent-cluster"
+# kubernetes_version = "v1.30.0"
+# vcn_cidr           = "10.0.0.0/16"
+
+# -- Node pools (optional overrides) --------------------------------------
+# cpu_node_shape = "VM.Standard.E4.Flex"
+# cpu_node_count = 3
+# gpu_node_shape = "VM.GPU.A10.1"
+# gpu_node_count = 1
+
+# -- Application (optional overrides) -------------------------------------
+# namespace           = "docs-agent"
+# docs_agent_image    = "ghcr.io/kubeflow/docs-agent:latest"
+# docs_agent_replicas = 2
+# milvus_storage_gb   = 50

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "fingerprint" {
 }
 
 variable "private_key" {
-  description = "Private key content (or path via file()) for OCI API auth."
+  description = "PEM-encoded private key for OCI API auth. Use file() or a secrets manager — never commit raw key material."
   type        = string
   sensitive   = true
 }
@@ -47,7 +47,7 @@ variable "cluster_name" {
 variable "kubernetes_version" {
   description = "Kubernetes version for the OKE cluster."
   type        = string
-  default     = "v1.28.2"
+  default     = "v1.30.0"
 }
 
 variable "vcn_cidr" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,109 @@
+# ---------------------------------------------------------------------------
+# Input variables for the root module
+# ---------------------------------------------------------------------------
+
+# -- OCI authentication ----------------------------------------------------
+
+variable "tenancy_ocid" {
+  description = "OCID of the OCI tenancy."
+  type        = string
+}
+
+variable "user_ocid" {
+  description = "OCID of the OCI user."
+  type        = string
+}
+
+variable "fingerprint" {
+  description = "Fingerprint for the OCI API signing key."
+  type        = string
+}
+
+variable "private_key" {
+  description = "Private key content (or path via file()) for OCI API auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "OCI region (e.g. us-ashburn-1)."
+  type        = string
+  default     = "us-ashburn-1"
+}
+
+variable "compartment_id" {
+  description = "OCID of the compartment to deploy resources into."
+  type        = string
+}
+
+# -- OKE cluster -----------------------------------------------------------
+
+variable "cluster_name" {
+  description = "Name for the OKE Kubernetes cluster."
+  type        = string
+  default     = "docs-agent-cluster"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the OKE cluster."
+  type        = string
+  default     = "v1.28.2"
+}
+
+variable "vcn_cidr" {
+  description = "CIDR block for the VCN."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+# -- Node pools ------------------------------------------------------------
+
+variable "cpu_node_shape" {
+  description = "OCI shape for CPU worker nodes."
+  type        = string
+  default     = "VM.Standard.E4.Flex"
+}
+
+variable "cpu_node_count" {
+  description = "Number of CPU worker nodes."
+  type        = number
+  default     = 3
+}
+
+variable "gpu_node_shape" {
+  description = "OCI shape for GPU worker nodes (for KServe LLM inference)."
+  type        = string
+  default     = "VM.GPU.A10.1"
+}
+
+variable "gpu_node_count" {
+  description = "Number of GPU worker nodes."
+  type        = number
+  default     = 1
+}
+
+# -- Application -----------------------------------------------------------
+
+variable "namespace" {
+  description = "Kubernetes namespace for the docs-agent stack."
+  type        = string
+  default     = "docs-agent"
+}
+
+variable "docs_agent_image" {
+  description = "Container image for the docs-agent servers."
+  type        = string
+  default     = "ghcr.io/kubeflow/docs-agent:latest"
+}
+
+variable "docs_agent_replicas" {
+  description = "Number of docs-agent pod replicas."
+  type        = number
+  default     = 2
+}
+
+variable "milvus_storage_gb" {
+  description = "Persistent volume size in GB for Milvus data."
+  type        = number
+  default     = 50
+}


### PR DESCRIPTION
## Summary

Adds `terraform/` — a complete Terraform scaffolding for deploying docs-agent on Oracle Cloud Infrastructure (OCI) with OKE, Milvus, KServe, and the docs-agent servers:

### Module Structure

```
terraform/
├── main.tf              # Root module: providers + 4 module calls
├── variables.tf         # All input variables with sensible defaults
├── outputs.tf           # Cluster endpoint, Milvus/KServe/docs-agent URLs
├── README.md            # Architecture diagram and quickstart
└── modules/
    ├── oke/main.tf      # VCN, subnets, OKE cluster, CPU + GPU node pools
    ├── milvus/main.tf   # Helm release for Milvus standalone
    ├── kserve/main.tf   # cert-manager + Knative Serving + KServe via Helm
    └── docs-agent/main.tf  # WS + HTTPS Deployments and Services
```

### Key Design Decisions

- **OKE with GPU node pool**: Supports GPU-accelerated embedding and inference workloads.
- **Milvus via Helm**: Standalone mode for development, can be swapped to cluster mode for production.
- **KServe stack**: Installs full dependency chain (cert-manager → Knative → KServe) for model serving with scale-to-zero.
- **Both server variants**: Deploys WebSocket and HTTPS servers side by side.
- **No state backend configured**: Users choose their own (OCI Object Storage, S3, etc.).

## Depends on

This PR is stacked on #49 (refactor: extract shared config and utilities for API servers).

## Related Issues

- Deployment reference deliverable for #60 (GSoC 2026: Agentic RAG on Kubeflow)
- No other contributor is working on Terraform/OCI deployment