### PR TITLE
fix(server): Offload blocking PyMilvus calls to thread pool to unfreeze ASGI loop (#82)

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -1,5 +1,6 @@
 import os
 import json
+import asyncio
 import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
@@ -177,7 +178,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, top_k)
+            result = await asyncio.to_thread(milvus_search, query, top_k)
             
             # Collect citations
             citations = []

--- a/server/app.py
+++ b/server/app.py
@@ -154,7 +154,7 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
             top_k = arguments.get("top_k", 5)
             
             print(f"[TOOL] Executing Milvus search for: '{query}' (top_k={top_k})")
-            result = milvus_search(query, top_k)
+            result = await asyncio.to_thread(milvus_search, query, top_k)
             
             # Collect citations
             citations = []


### PR DESCRIPTION
## Summary

- Closes #82
- Stacked on #83 (this PR targets `main`;
  - but assumes #83 lands first)

This PR resolves a concurrency defect where synchronous calls to `pymilvus` were executing directly on the `asyncio` event loop. By using `asyncio.to_thread()`, all blocking model loading (`SentenceTransformer`) and gRPC calls to Milvus are safely offloaded to the default thread pool executor, maintaining high throughput for the web servers. 

## What Changed
- In `server-https/app.py` and `server/app.py`, modified `milvus_search(...)` invocation within `execute_tool()` to yield to the event loop.

## Testing
Tested locally with concurrent connections verifying SSE flow is uninterrupted.
