### PR TITLE
fix(kagent): Replace Groq model placeholder with llama-3.1-8b-instant (#88)

### DIFF
--- a/kagent-feast-mcp/manifests/kagent/setup.yaml
+++ b/kagent-feast-mcp/manifests/kagent/setup.yaml
@@ -13,12 +13,12 @@ stringData:
 apiVersion: kagent.dev/v1alpha2
 kind: ModelConfig
 metadata:
-  name: groq-llama  
+  name: groq-llama
   namespace: <YOUR_NAMESPACE>
 spec:
   apiKeySecret: kagent-groq
   apiKeySecretKey: GROQ_API_KEY
-  model: <model of your choice>
+  model: "llama-3.1-8b-instant"
   provider: OpenAI
   openAI:
     baseUrl: "https://api.groq.com/openai/v1"


### PR DESCRIPTION
## Summary

- Closes #88

`setup.yaml` ships with `<model of your choice>` placeholder instead of a working model, or older forks had `llama3-8b-8192` which Groq decommissioned.

The agent pod returns `400 model_decommissioned` on every LLM call if the old model is used, and fails if the placeholder is left. Replacing it with `llama-3.1-8b-instant` provides a working out-of-the-box experience.

## What Changed

| File                                              | Change                                              |
| ------------------------------------------------- | --------------------------------------------------- |
| `kagent-feast-mcp/manifests/kagent/setup.yaml:21` | `<model of your choice>` → `"llama-3.1-8b-instant"` |

## Testing

```bash
kubectl apply -f kagent-feast-mcp/manifests/kagent/setup.yaml
kubectl delete pod -l kagent=kubeflow-docs-agent -n docs-agent
kubectl logs -f deployment/kubeflow-docs-agent -n docs-agent
# → No 400 errors. LLM responds to queries.
```

## Related

- Closes #88
- Context: #59 (comment) — discovered during local PoC validation
