### PR TITLE
docs(kagent): Add WSL2/Kind memory prerequisites and Milvus resource constraints (#92)

### DIFF
--- a/kagent-feast-mcp/README.md
+++ b/kagent-feast-mcp/README.md
@@ -13,6 +13,7 @@ Deploy the Kubeflow documentation assistant using kagent, MCP, Feast, and Milvus
 - Python 3.9+
 - A Groq API key (or other OpenAI-compatible LLM provider)
 - Container registry (e.g. Docker Hub) to push the MCP server image
+- **For WSL2 / remote dev:** At least 4-5GB of host RAM available. If running Docker/Kind on WSL2, set `.wslconfig` `memory=4GB` (min) and use the `values-local.yaml` overlay shown below, otherwise Milvus may trigger the Linux OOMKiller.
 
 ## Placeholders and how to fill them
 
@@ -51,7 +52,20 @@ Deploy the Kubeflow documentation assistant using kagent, MCP, Feast, and Milvus
 helm repo add zilliztech https://zilliztech.github.io/milvus-helm/
 helm repo update
 
+# For standard cloud deployments:
+# helm upgrade --install milvus zilliztech/milvus -n <YOUR_NAMESPACE> \
+#   --set cluster.enabled=false \
+#   --set standalone.enabled=true \
+#   --set etcd.replicaCount=1 \
+#   --set etcd.persistence.enabled=false \
+#   --set minio.mode=standalone \
+#   --set minio.replicas=1 \
+#   --set pulsar.enabled=false \
+#   --set pulsarv3.enabled=false
+
+# For local dev / WSL2 / Kind (prevents OOM crashes):
 helm upgrade --install milvus zilliztech/milvus -n <YOUR_NAMESPACE> \
+  -f manifests/overlays/dev/values-local.yaml \
   --set cluster.enabled=false \
   --set standalone.enabled=true \
   --set etcd.replicaCount=1 \
@@ -82,11 +96,11 @@ If pods show `2/2`, the cluster's `global-deny-all` policy blocks traffic by def
 kubectl apply -f manifests/istio/
 ```
 
-| Policy | Target | Ports | Purpose |
-|--------|--------|-------|---------|
+| Policy                    | Target            | Ports       | Purpose                 |
+| ------------------------- | ----------------- | ----------- | ----------------------- |
 | `allow-milvus-standalone` | Milvus standalone | 19530, 9091 | App access to vector DB |
-| `allow-milvus-etcd` | etcd | 2379, 2380 | Milvus metadata storage |
-| `allow-milvus-minio` | MinIO | 9000, 9001 | Milvus object storage |
+| `allow-milvus-etcd`       | etcd              | 2379, 2380  | Milvus metadata storage |
+| `allow-milvus-minio`      | MinIO             | 9000, 9001  | Milvus object storage   |
 
 ### Step 3: Test Milvus Connection
 

--- a/kagent-feast-mcp/manifests/overlays/dev/values-local.yaml
+++ b/kagent-feast-mcp/manifests/overlays/dev/values-local.yaml
@@ -1,0 +1,30 @@
+# values-local.yaml
+# Lightweight configuration for local Kind/Minikube/WSL2 deployments
+# Prevents OOM kills when deploying Milvus on hosts with <= 8GB RAM
+
+etcd:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+minio:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+standalone:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi


### PR DESCRIPTION
## Summary

- Closes #92

Deploying the standalone Milvus Helm chart on a default WSL2 or Kind cluster triggers OOM kills — etcd, minio, and milvus-standalone collectively exceed the 4–5GB available on standard developer setups.
This PR adds `values-local.yaml` with constrained resource requests, and documents the WSL2 memory prerequisites in the README, unblocking local development.

## What Changed

| File                                                        | Change                                                                              |
| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| `kagent-feast-mcp/manifests/overlays/dev/values-local.yaml` | **New** — Milvus Helm values with memory/CPU limits tailored for local Kind setups. |
| `kagent-feast-mcp/README.md`                                | Added WSL2 prerequisites section and a patched helm upgrade command.                |

## Why This Approach

Rather than documenting a workaround to force users to allocate 12GB+ RAM to WSL2, keeping the application scalable and configurable via Helm overrides is a cleaner pattern that makes the codebase accessible to a larger pool of contributors on smaller machines.

## Testing

```bash
# On 8GB Windows host, WSL2 memory=4GB:
helm upgrade --install milvus zilliztech/milvus \
  -n docs-agent -f kagent-feast-mcp/manifests/overlays/dev/values-local.yaml \
  --set cluster.enabled=false \
  --set standalone.enabled=true \
  --set etcd.replicaCount=1 \
  --set etcd.persistence.enabled=false \
  --set minio.mode=standalone \
  --set minio.replicas=1 \
  --set pulsar.enabled=false \
  --set pulsarv3.enabled=false

kubectl get pods -n docs-agent
# → milvus-etcd, milvus-minio, milvus-standalone all Running
# → No OOMKilled events observed even under load
```

- [x] Tested on 8GB host with WSL2 configured to 4GB limits.
- [x] Pods achieve `Running` state without crash looping.

## Related

- Closes #92
- Context: #59 (comment) — Issue discovered during local PoC validation
