### PR TITLE
feat: parameterize embedding dimensions for flexible model selection

### DIFF
--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -326,7 +326,8 @@ def store_milvus(
     embedded_data: dsl.Input[dsl.Dataset],
     milvus_host: str,
     milvus_port: str,
-    collection_name: str
+    collection_name: str,
+    embedding_dimension: int = 768  # Parameterized embedding dimension
 ):
     from pymilvus import connections, utility, FieldSchema, CollectionSchema, DataType, Collection
     import json
@@ -339,7 +340,7 @@ def store_milvus(
         utility.drop_collection(collection_name)
         print(f"Dropped existing collection: {collection_name}")
 
-    # Enhanced schema with 768 dimensions
+    # Enhanced schema with dynamic embedding dimension
     fields = [
         FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
         FieldSchema(name="file_unique_id", dtype=DataType.VARCHAR, max_length=512),
@@ -349,14 +350,14 @@ def store_milvus(
         FieldSchema(name="citation_url", dtype=DataType.VARCHAR, max_length=1024),
         FieldSchema(name="chunk_index", dtype=DataType.INT64),
         FieldSchema(name="content_text", dtype=DataType.VARCHAR, max_length=2000),
-        FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=768),  # Updated for all-mpnet-base-v2
+        FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=embedding_dimension),  # Parameterized dimension
         FieldSchema(name="last_updated", dtype=DataType.INT64)
     ]
 
     # Create new collection with correct schema
     schema = CollectionSchema(fields, "RAG collection for documentation")
     collection = Collection(collection_name, schema)
-    print(f"Created new collection: {collection_name}")
+    print(f"Created new collection: {collection_name} with embedding dimension: {embedding_dimension}")
 
     # Rest of your existing code remains the same...
     records = []
@@ -410,7 +411,8 @@ def github_rag_pipeline(
     chunk_overlap: int = 100,
     milvus_host: str = "milvus-standalone-final.docs-agent.svc.cluster.local",
     milvus_port: str = "19530",
-    collection_name: str = "docs_rag"
+    collection_name: str = "docs_rag",
+    embedding_dimension: int = 768  # Parameterized embedding dimension for all-mpnet-base-v2
 ):
     # Download GitHub directory
     download_task = download_github_directory(
@@ -434,7 +436,8 @@ def github_rag_pipeline(
         embedded_data=chunk_task.outputs["embedded_data"],
         milvus_host=milvus_host,
         milvus_port=milvus_port,
-        collection_name=collection_name
+        collection_name=collection_name,
+        embedding_dimension=embedding_dimension
     )
 
 


### PR DESCRIPTION
## Problem

Embedding dimension is hard-coded to `768` in pipeline schemas, which locks the 
system to a single embedding model (`sentence-transformers/all-mpnet-base-v2`).

### Current Limitation

Cannot switch to alternative embedding models without code changes:
- Cannot optimize for speed (newer models are 3-10x faster)
- Cannot optimize for memory (new models use 50-90% less RAM)
- Cannot optimize for domain-specific use cases (legal/medical/code)
- Cannot take advantage of improved models without schema migration


## Solution

Made embedding dimension a configurable parameter with sensible defaults:
- Default: `768` (maintains backward compatibility)
- Configurable: Can be set to any value
- Clear: Shows relationship between model and dimension

## Files Modified

- `pipelines/kubeflow-pipeline.py`:
  - Function: `store_milvus()` - Added `embedding_dimension` parameter
  - Function: `github_rag_pipeline()` - Added `embedding_dimension` parameter
  - Schema: Uses `embedding_dimension` instead of hard-coded `768`

- `pipelines/incremental-pipeline.py`:
  - Function: `store_milvus_incremental()` - Added `embedding_dimension` parameter
  - Function: `github_rag_incremental_pipeline()` - Added `embedding_dimension` parameter
  - Schema: Uses `embedding_dimension` instead of hard-coded `768`

