### PR TITLE
Fix: Initialize embedding model once at startup to avoid per-request reload (#63)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -22,6 +22,11 @@ MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
 MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
 
+# Initialize embedding model ONCE at startup 
+print(f" Loading embedding model: {EMBEDDING_MODEL}")
+EMBEDDING_ENCODER = SentenceTransformer(EMBEDDING_MODEL)
+print("Embedding model loaded successfully")
+
 # System prompt
 SYSTEM_PROMPT = """
 You are the Kubeflow Docs Assistant.


### PR DESCRIPTION
The SentenceTransformer embedding model was being instantiated inside the milvus_search() function for every request.
This caused:
Repeated model loading overhead
Increased latency per query
Unnecessary memory churn under concurrent traffic
Model initialization time was dominating overall query latency.
Solution
This PR initializes the embedding model once at server startup:
print(f" Loading embedding model: {EMBEDDING_MODEL}")
EMBEDDING_ENCODER = SentenceTransformer(EMBEDDING_MODEL)
print("Embedding model loaded successfully")
Impact
Eliminates repeated model instantiation
Reduces per-request latency
Improves memory efficiency
Aligns with production best practices for embedding services
This makes the docs-agent more scalable and better suited for real-world traffic.
