### PR TITLE
Fix: Reuse preloaded SentenceTransformer instead of re-instantiating …

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -73,9 +73,10 @@ def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
         collection = Collection(MILVUS_COLLECTION)
         collection.load()
 
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
+        # Reuse preloaded embedding model (fix for issue #63)
+        query_vec = EMBEDDING_ENCODER.encode(query).tolist()
+        
+        
 
         search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
         results = collection.search(


### PR DESCRIPTION
…per request (#63)

Fix: Reuse preloaded SentenceTransformer instead of re-instantiating per request (#63)

Remove per-request model initialization inside milvus_search() and use the globally initialized EMBEDDING_ENCODER. This eliminates repeated model loading, reduces latency, and improves memory efficiency.