### PR TITLE
Fix: Use preloaded embedding model in milvus_search() (#63)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -73,9 +73,8 @@ def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
         collection = Collection(MILVUS_COLLECTION)
         collection.load()
 
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
+        # Use preloaded embedding model (fix for issue #63)
+        query_vec = EMBEDDING_ENCODER.encode(query).tolist()
 
         search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
         results = collection.search(
@@ -88,22 +87,25 @@ def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
 
         hits = []
         for hit in results[0]:
-            # similarity = 1 - distance for COSINE in Milvus
             similarity = 1.0 - float(hit.distance)
             entity = hit.entity
             content_text = entity.get("content_text") or ""
             if isinstance(content_text, str) and len(content_text) > 400:
                 content_text = content_text[:400] + "..."
+
             hits.append({
                 "similarity": similarity,
                 "file_path": entity.get("file_path"),
                 "citation_url": entity.get("citation_url"),
                 "content_text": content_text,
             })
+
         return {"results": hits}
+
     except Exception as e:
         print(f"[ERROR] Milvus search failed: {e}")
         return {"results": []}
+
     finally:
         try:
             connections.disconnect(alias="default")


### PR DESCRIPTION
Previously, the SentenceTransformer model was instantiated inside milvus_search() for every query. This caused unnecessary model reloads, increased response latency, and avoidable memory churn under repeated traffic.

This change removes per-request model initialization and reuses a globally preloaded EMBEDDING_ENCODER instance initialized at server startup. The model is now loaded once per process and shared across all search calls.

Benefits:
- Reduces per-query latency
- Eliminates repeated model loading overhead
- Improves memory efficiency
- Aligns with production best practices for embedding services