### PR TITLE
fix(mcp-server): replace hardcoded milvus config with environment variables

### DIFF
--- a/kagent-feast-mcp/manifests/mcp-server/mcp-server.yaml
+++ b/kagent-feast-mcp/manifests/mcp-server/mcp-server.yaml
@@ -23,6 +23,12 @@ spec:
               value: "8000"
             - name: PYTHONUNBUFFERED
               value: "1"
+            - name: MILVUS_URI
+              value: "http://milvus.docs-agent.svc.cluster.local:19530"
+            - name: MILVUS_USER
+              value: "root"
+            - name: MILVUS_PASSWORD
+              value: "Milvus"
           readinessProbe:
             tcpSocket:
               port: 8000
@@ -53,3 +59,4 @@ spec:
     - port: 8000
       targetPort: 8000
   type: ClusterIP
+  

--- a/kagent-feast-mcp/mcp-server/server.py
+++ b/kagent-feast-mcp/mcp-server/server.py
@@ -1,10 +1,11 @@
+import os
 from fastmcp import FastMCP
 from pymilvus import MilvusClient
 from sentence_transformers import SentenceTransformer
 
-MILVUS_URI = "http://milvus.<YOUR_NAMESPACE>.svc.cluster.local:19530"
-MILVUS_USER = "root"
-MILVUS_PASSWORD = "Milvus"
+MILVUS_URI = os.getenv("MILVUS_URI", "http://milvus.<YOUR_NAMESPACE>.svc.cluster.local:19530")
+MILVUS_USER = os.getenv("MILVUS_USER", "root")
+MILVUS_PASSWORD = os.getenv("MILVUS_PASSWORD", "Milvus")
 COLLECTION_NAME = "kubeflow_docs_docs_rag"
 EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
 PORT = 8000
@@ -62,3 +63,4 @@ def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
 
 if __name__ == "__main__":
     mcp.run(transport="streamable-http", host="0.0.0.0", port=PORT)
+


### PR DESCRIPTION
Fixes #91

Problem:
The Milvus connection parameters (MILVUS_URI, MILVUS_USER, MILVUS_PASSWORD) in mcp-server/server.py were hardcoded. This caused silent connection failures in environments outside of the exact docs-agent namespace and prevented dynamic configuration via Kubernetes manifests without requiring a Docker image rebuild.

Solution:
1. Backend: Modified kagent-feast-mcp/mcp-server/server.py to utilize os.getenv for credentials and URI. Preserved the original <YOUR_NAMESPACE> placeholder as the default fallback to maintain visibility for new developers.
2. Manifests: Updated kagent-feast-mcp/manifests/mcp-server/mcp-server.yaml to inject the explicit docs-agent routing values via the container's env block.

This enables clean, environment-specific overrides (like Kustomize overlays or local .env files) while keeping the source code flexible across deployment targets.

Validation Performed:
• Commits DCO signed-off.
• Python syntax validated via py_compile.
• Code passes official Kubeflow linting (ruff check).
• YAML structural integrity and POSIX newline formatting verified.