### PR TITLE
(Fix)guard against empty chunk list in pipeline logging

### DIFF
--- a/pipelines/incremental-pipeline.py
+++ b/pipelines/incremental-pipeline.py
@@ -220,7 +220,11 @@ def chunk_and_embed_incremental(
             # Split into chunks
             chunks = text_splitter.split_text(content)
 
-            print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {sum(len(c) for c in chunks)/len(chunks):.0f} chars)")
+            if chunks:
+                avg_len = sum(len(c) for c in chunks) / len(chunks)
+                print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {avg_len:.0f} chars)")
+            else:
+                print(f"File: {file_data['path']} -> 0 chunks (skipped after cleaning)")
 
             # Create embeddings
             for chunk_idx, chunk in enumerate(chunks):

--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -295,7 +295,11 @@ def chunk_and_embed(
             # Split into chunks
             chunks = text_splitter.split_text(content)
 
-            print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {sum(len(c) for c in chunks)/len(chunks):.0f} chars)")
+            if chunks:
+                avg_len = sum(len(c) for c in chunks) / len(chunks)
+                print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {avg_len:.0f} chars)")
+            else:
+                print(f"File: {file_data['path']} -> 0 chunks (skipped after cleaning)")
 
             # Create embeddings
             for chunk_idx, chunk in enumerate(chunks):


### PR DESCRIPTION
The text splitting method in both kubeflow-pipeline.py and incremental-pipelines.py could return a empty a list when the file's content is completely removed by the cleaning regexes. The method to find the average chunk length could trigger a ZeroDivisionError and abort the pipeline. 

This PR adds a simple guard that when chunks isn't empty go with the usual flow and when it is empty then log 0 chunks (skipping) and continue. 