### PR TITLE
security(server): replace CORS wildcard with env-var allowlist

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -28,6 +28,11 @@ ALLOWED_ORIGINS = [
     for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
     if origin.strip()
 ]
+if "*" in ALLOWED_ORIGINS:
+    raise ValueError(
+        "ALLOWED_ORIGINS must not contain '*'. "
+        "List specific origins (e.g. 'https://app.example.com,https://admin.example.com')."
+    )
 
 # System prompt (same as WebSocket version)
 SYSTEM_PROMPT = """

--- a/server-https/app.py
+++ b/server-https/app.py
@@ -22,6 +22,13 @@ MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
 MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
 
+# CORS Config
+ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if origin.strip()
+]
+
 # System prompt (same as WebSocket version)
 SYSTEM_PROMPT = """
 You are the Kubeflow Docs Assistant.
@@ -101,7 +108,7 @@ app = FastAPI(title="Kubeflow Docs API Service", version="1.0.0")
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify your actual domains
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -420,8 +427,6 @@ async def chat(request: ChatRequest):
                 headers={
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
-                    "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Headers": "Cache-Control"
                 }
             )
         else:

--- a/server-https/deployment.yaml
+++ b/server-https/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: "8000"
             - name: PYTHONUNBUFFERED
               value: "1"
+            - name: ALLOWED_ORIGINS
+              value: "http://localhost:3000"
 
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary

Fixes #76 — replaces hardcoded `allow_origins=["*"]` with a configurable `ALLOWED_ORIGINS` environment variable, and hardens the deployment manifest and startup validation.

### Changes

**Commit 1 — `server-https/app.py`**
- **Environment-based CORS config**: Parse `ALLOWED_ORIGINS` env var (comma-separated), defaulting to `http://localhost:3000` for local development
- **CORSMiddleware update**: Use the parsed allowlist instead of `["*"]`
- **Remove redundant headers**: Removed manual `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers` from SSE response — `CORSMiddleware` handles this centrally

**Commit 2 — `server-https/deployment.yaml`**
- **Declare env var in K8s manifest**: Added `ALLOWED_ORIGINS` to the container's `env:` block so Kubernetes actually injects it at runtime. Without this, the container never receives the variable and CORS defaults to `http://localhost:3000` in all environments.

**Commit 3 — `server-https/app.py`**
- **Wildcard guard**: Reject `ALLOWED_ORIGINS=*` at startup with a clear `ValueError`. Starlette's `CORSMiddleware` treats `["*"]` as `allow_all_origins=True`, and combined with `allow_credentials=True`, this creates origin-reflection where any requesting origin is echoed back with credentials — worse than the original wildcard.

### Usage

```bash
# Development (default)
# No env var needed — defaults to http://localhost:3000

# Production
export ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"

# Kubernetes (override in deployment config, ConfigMap, or Kustomize overlay)
# See server-https/deployment.yaml
```

### Why this matters

A wildcard CORS policy allows any origin to make credentialed cross-origin requests to the server. This is a security risk in production, especially for an API that handles document queries and agent interactions. The env-var approach lets operators lock down origins per deployment without code changes.

**Follow-up**: `ALLOWED_ORIGINS` is not yet documented in the README's Environment Variables table. Happy to add that in a separate PR if desired.

Signed-off-by: Michael Piscitelli <hello@herakles.dev>