### PR TITLE
refactor(pipelines): use clean_content utility in incremental pipeline

### DIFF
--- a/pipelines/incremental-pipeline.py
+++ b/pipelines/incremental-pipeline.py
@@ -152,8 +152,8 @@ def chunk_and_embed_incremental(
 ):
     import json
     import os
-    import re
     import torch
+    from shared.text_utils import clean_content
     from sentence_transformers import SentenceTransformer
     from langchain.text_splitter import RecursiveCharacterTextSplitter
 
@@ -168,29 +168,9 @@ def chunk_and_embed_incremental(
             file_data = json.loads(line)
             content = file_data['content']
 
-            # AGGRESSIVE CLEANING FOR BETTER EMBEDDINGS (same as original)
-            
-            # Remove Hugo frontmatter (both --- and +++ styles)
-            content = re.sub(r'^\s*[+\-]{3,}.*?[+\-]{3,}\s*', '', content, flags=re.DOTALL | re.MULTILINE)
-
-            # Remove Hugo template syntax
-            content = re.sub(r'\{\{.*?\}\}', '', content, flags=re.DOTALL)
-
-            # Remove HTML comments and tags
-            content = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
-            content = re.sub(r'<[^>]+>', ' ', content)
-
-            # Remove navigation/menu artifacts
-            content = re.sub(r'\b(Get Started|Contribute|GenAI|Home|Menu|Navigation)\b', '', content, flags=re.IGNORECASE)
-
-            # Clean up URLs and links
-            content = re.sub(r'https?://[^\s]+', '', content)
-            content = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', content)  # Convert [text](url) to text
-
-            # Remove excessive whitespace and normalize
-            content = re.sub(r'\s+', ' ', content)  # Multiple spaces to single
-            content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)  # Multiple newlines to double
-            content = content.strip()
+            # Clean documentation text using shared utility
+            content = clean_content(content)
+    
 
             # Skip files that are too short after cleaning
             if len(content) < 50:


### PR DESCRIPTION
Refactored incremental-pipeline.py to use the shared clean_content() utility from shared/text_utils.py.

Changes:
- Imported clean_content from shared.text_utils
- Removed duplicated regex-based text cleaning logic
- Replaced inline preprocessing with clean_content(content)

This ensures consistent text preprocessing across ingestion pipelines and improves maintainability by following DRY principles.

Fixes #81
Related: #72