### PR TITLE
fix(kagent): set working default Groq model in setup.yaml

### DIFF
--- a/kagent-feast-mcp/manifests/kagent/setup.yaml
+++ b/kagent-feast-mcp/manifests/kagent/setup.yaml
@@ -18,7 +18,8 @@ metadata:
 spec:
   apiKeySecret: kagent-groq
   apiKeySecretKey: GROQ_API_KEY
-  model: <model of your choice>
+  # Valid Groq model examples: llama-3.1-8b-instant, llama-3.3-70b-versatile
+  model: llama-3.1-8b-instant
   provider: OpenAI
   openAI:
     baseUrl: "https://api.groq.com/openai/v1"


### PR DESCRIPTION
Fixes #88

## Changes
- Replaced the placeholder Groq model in `setup.yaml`
- Set a working default model: `llama-3.1-8b-instant`
- Added a YAML comment listing other valid model options

## Why
This avoids `model_decommissioned` errors and makes the setup easier for new contributors.