### PR TITLE
fix: Replace hardcoded Milvus credentials with env vars (fixes #91) 

### DIFF
--- a/kagent-feast-mcp/mcp-server/server.py
+++ b/kagent-feast-mcp/mcp-server/server.py
@@ -1,10 +1,11 @@
+import os
 from fastmcp import FastMCP
 from pymilvus import MilvusClient
 from sentence_transformers import SentenceTransformer
 
-MILVUS_URI = "http://milvus.<YOUR_NAMESPACE>.svc.cluster.local:19530"
-MILVUS_USER = "root"
-MILVUS_PASSWORD = "Milvus"
+MILVUS_URI = os.environ["MILVUS_URI"]
+MILVUS_USER = os.environ["MILVUS_USER"]
+MILVUS_PASSWORD = os.environ["MILVUS_PASSWORD"]
 COLLECTION_NAME = "kubeflow_docs_docs_rag"
 EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
 PORT = 8000


### PR DESCRIPTION
Fixes #91 

## Changes
- Replaced hardcoded MILVUS_URI, MILVUS_USER,
  MILVUS_PASSWORD with os.environ[] calls
- No default fallbacks per maintainer guidance
- Allows Kustomize overlays to inject correct
  values per environment

## Sanity Check
Server starts successfully with env vars:

<img width="1916" height="705" alt="image" src="https://github.com/user-attachments/assets/72a72977-0a7e-44e4-b7e3-209f39012eb2" />

Tested locally on Windows/PowerShell.

Related: #59 
cc: @SanthoshToorpu 