### PR TITLE
feat: add search_github_issues MCP tool and issues ingestion pipeline

### DIFF
--- a/kagent-feast-mcp/manifests/kagent/setup.yaml
+++ b/kagent-feast-mcp/manifests/kagent/setup.yaml
@@ -13,7 +13,7 @@ stringData:
 apiVersion: kagent.dev/v1alpha2
 kind: ModelConfig
 metadata:
-  name: groq-llama  
+  name: groq-llama
   namespace: <YOUR_NAMESPACE>
 spec:
   apiKeySecret: kagent-groq
@@ -31,18 +31,18 @@ metadata:
   name: kubeflow-docs-mcp
   namespace: <YOUR_NAMESPACE>
 spec:
-  description: "MCP server for searching Kubeflow documentation via Feast and Milvus"
+  description: "MCP server for searching Kubeflow documentation and GitHub issues via Milvus"
   url: http://mcp-kubeflow-docs.<YOUR_NAMESPACE>.svc.cluster.local:8000/mcp
 
 ---
-# 4. Agent with MCP tool
+# 4. Agent with MCP tools
 apiVersion: kagent.dev/v1alpha2
 kind: Agent
 metadata:
   name: kubeflow-docs-agent
   namespace: <YOUR_NAMESPACE>
 spec:
-  description: "Kubeflow documentation assistant"
+  description: "Kubeflow documentation and issues assistant"
   type: Declarative
   declarative:
     modelConfig: groq-llama
@@ -53,6 +53,7 @@ spec:
           kind: RemoteMCPServer
           toolNames:
             - search_kubeflow_docs
+            - search_github_issues
     systemMessage: |-
       You are the Kubeflow Docs Assistant.
 
@@ -63,20 +64,26 @@ spec:
       Your role
       - Always answer the user's question directly.
       - If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
-      - If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
+      - If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the appropriate tool and construct your response using the information provided.
 
       Tool Use
-      - Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
-      - Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
-      - When you do call the tool:
+      - Use search_kubeflow_docs for official documentation: setup guides, API references, concepts, architecture, configuration.
+      - Use search_github_issues for troubleshooting: error messages, known bugs, workarounds, community solutions, issue discussions.
+      - Do NOT use tools for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
+      - CRITICAL: When calling search_github_issues:
+        - Do NOT set the repo or state filters. Always leave them empty. The semantic search works best across all repos without filters.
+        - The only exception is if the user explicitly says something like "search in kubeflow/pipelines repo" or "show me only open issues".
+      - When you do call a tool:
         - Use one clear, focused query.
         - Summarize the result in your own words.
-        - If no results are relevant, say "not found in the docs" and suggest refining the query.
+        - If no results are relevant, say "not found" and suggest refining the query.
 
       Routing
       - Greetings/small talk: respond briefly, no tool.
       - Out-of-scope (sports, unrelated topics): politely say you only help with Kubeflow.
-      - Kubeflow-specific: answer and call the tool if documentation is needed.
+      - Kubeflow-specific docs/concepts: use search_kubeflow_docs.
+      - Error messages, bugs, known issues, troubleshooting: use search_github_issues.
+      - If unclear, try search_kubeflow_docs first, then search_github_issues if docs are insufficient.
 
       Style
       - Be concise (2-5 sentences). Use bullet points or steps when helpful.

--- a/kagent-feast-mcp/mcp-server/server.py
+++ b/kagent-feast-mcp/mcp-server/server.py
@@ -1,13 +1,16 @@
+import os
+
 from fastmcp import FastMCP
 from pymilvus import MilvusClient
 from sentence_transformers import SentenceTransformer
 
-MILVUS_URI = "http://milvus.<YOUR_NAMESPACE>.svc.cluster.local:19530"
-MILVUS_USER = "root"
-MILVUS_PASSWORD = "Milvus"
-COLLECTION_NAME = "kubeflow_docs_docs_rag"
-EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
-PORT = 8000
+MILVUS_URI = os.getenv("MILVUS_URI", "http://localhost:19530")
+MILVUS_USER = os.getenv("MILVUS_USER", "root")
+MILVUS_PASSWORD = os.getenv("MILVUS_PASSWORD", "Milvus")
+COLLECTION_NAME = os.getenv("COLLECTION_NAME", "kubeflow_docs_docs_rag")
+ISSUES_COLLECTION_NAME = os.getenv("ISSUES_COLLECTION_NAME", "issues_rag")
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
+PORT = int(os.getenv("PORT", "8000"))
 
 mcp = FastMCP("Kubeflow Docs MCP Server")
 
@@ -23,6 +26,50 @@ def _init():
         client = MilvusClient(uri=MILVUS_URI, user=MILVUS_USER, password=MILVUS_PASSWORD)
 
 
+def _search_collection(
+    collection_name: str,
+    query: str,
+    top_k: int,
+    output_fields: list,
+    filter_expr: str = "",
+) -> str:
+    """Shared search-and-format logic for all MCP search tools."""
+    _init()
+
+    embedding = model.encode(query).tolist()
+
+    search_params = dict(
+        collection_name=collection_name,
+        data=[embedding],
+        limit=top_k,
+        output_fields=output_fields,
+    )
+    if filter_expr:
+        search_params["filter"] = filter_expr
+
+    hits = client.search(**search_params)[0]
+
+    if not hits:
+        return "No results found for your query."
+
+    results = []
+    for i, hit in enumerate(hits, 1):
+        entity = hit["entity"]
+        entry = f"### Result {i} (score: {hit['distance']:.4f})"
+        entry += f"\n**Source:** {entity.get('citation_url', '')}"
+        # Render additional fields (skip content_text and citation_url)
+        for field in output_fields:
+            if field in ("content_text", "citation_url"):
+                continue
+            val = entity.get(field, "")
+            if val != "" and val is not None:
+                entry += f"\n**{field}:** {val}"
+        entry += f"\n\n{entity.get('content_text', '')}\n"
+        results.append(entry)
+
+    return "\n---\n".join(results)
+
+
 @mcp.tool()
 def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
     """Search Kubeflow documentation using semantic similarity.
@@ -34,30 +81,40 @@ def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
     Returns:
         Formatted search results with content and citation URLs.
     """
-    _init()
-
-    embedding = model.encode(query).tolist()
-
-    hits = client.search(
+    return _search_collection(
         collection_name=COLLECTION_NAME,
-        data=[embedding],
-        limit=top_k,
+        query=query,
+        top_k=top_k,
         output_fields=["content_text", "citation_url", "file_path"],
-    )[0]
+    )
 
-    if not hits:
-        return "No results found for your query."
 
-    results = []
-    for i, hit in enumerate(hits, 1):
-        entity = hit["entity"]
-        entry = f"### Result {i} (score: {hit['distance']:.4f})"
-        entry += f"\n**Source:** {entity.get('citation_url', '')}"
-        entry += f"\n**File:** {entity.get('file_path', '')}"
-        entry += f"\n\n{entity.get('content_text', '')}\n"
-        results.append(entry)
+@mcp.tool()
+def search_github_issues(
+    query: str,
+    top_k: int = 5,
+) -> str:
+    """Search Kubeflow GitHub issues for bug reports, troubleshooting,
+    and community solutions. Searches across all repositories including
+    kubeflow/kubeflow, kubeflow/pipelines, kubeflow/manifests,
+    kubeflow/katib, kserve/kserve, and kubeflow/website.
 
-    return "\n---\n".join(results)
+    Args:
+        query: Search query about errors, bugs, or issues.
+        top_k: Number of results to return (default 5).
+
+    Returns:
+        Formatted search results with content and GitHub issue URLs.
+    """
+    return _search_collection(
+        collection_name=ISSUES_COLLECTION_NAME,
+        query=query,
+        top_k=top_k,
+        output_fields=[
+            "content_text", "citation_url", "repo_name",
+            "issue_number", "issue_state", "issue_labels",
+        ],
+    )
 
 
 if __name__ == "__main__":

--- a/pipelines/issues-pipeline.py
+++ b/pipelines/issues-pipeline.py
@@ -1,0 +1,415 @@
+"""KFP pipeline for ingesting GitHub issues into Milvus for RAG.
+
+Wires the existing download_github_issues component into a complete pipeline
+with issues-aware chunking and a dedicated issues_rag Milvus collection.
+
+Components are self-contained per KFP convention. The download_github_issues
+component is copied from kubeflow-pipeline.py (lines 67-213) since KFP
+@dsl.component functions must be self-contained with all imports inside.
+"""
+
+import kfp
+from kfp import dsl
+from kfp.dsl import *
+from typing import *
+
+
+@dsl.component(
+    base_image="python:3.9",
+    packages_to_install=["requests"]
+)
+def download_github_issues(
+    repos: str,
+    labels: str,
+    state: str,
+    max_issues_per_repo: int,
+    github_token: str,
+    issues_data: dsl.Output[dsl.Dataset]
+):
+    """Fetch GitHub issues and comments from multiple repos for RAG indexing.
+
+    Args:
+        repos: Comma-separated list of repos (e.g., "kubeflow/kubeflow,kubeflow/pipelines")
+        labels: Comma-separated labels to filter (e.g., "kind/bug,kind/question")
+        state: Issue state - "open", "closed", or "all"
+        max_issues_per_repo: Maximum issues to fetch per repository
+        github_token: GitHub personal access token for API authentication
+        issues_data: Output dataset path
+    """
+    import requests
+    import json
+    import time
+
+    headers = {"Authorization": f"token {github_token}"} if github_token else {}
+    all_issues = []
+
+    def api_request(url, params=None):
+        """Make GitHub API request with rate limit handling."""
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                resp = requests.get(url, params=params, headers=headers)
+
+                # Handle rate limiting
+                if resp.status_code == 403:
+                    remaining = resp.headers.get("X-RateLimit-Remaining", "0")
+                    if remaining == "0":
+                        reset_time = int(resp.headers.get("X-RateLimit-Reset", 0))
+                        wait_time = max(reset_time - int(time.time()), 60)
+                        print(f"Rate limited. Waiting {wait_time}s...")
+                        time.sleep(min(wait_time, 300))  # Max 5 min wait
+                        continue
+
+                if resp.status_code == 200:
+                    return resp.json()
+                else:
+                    print(f"API error: HTTP {resp.status_code}")
+                    return None
+
+            except Exception as e:
+                print(f"Request failed (attempt {attempt+1}): {e}")
+                time.sleep(2 ** attempt)  # Exponential backoff
+
+        return None
+
+    def fetch_comments(owner, name, issue_number):
+        """Fetch all comments for a single issue."""
+        comments_url = f"https://api.github.com/repos/{owner}/{name}/issues/{issue_number}/comments"
+        comments_text = ""
+        page = 1
+
+        while True:
+            comments = api_request(comments_url, {"per_page": 100, "page": page})
+            if not comments:
+                break
+
+            for comment in comments:
+                author = comment.get("user", {}).get("login", "unknown")
+                created = comment.get("created_at", "")[:10]
+                body = comment.get("body", "") or ""
+                comments_text += f"\n\n---\n**Comment by @{author}** ({created}):\n{body}"
+
+            if len(comments) < 100:
+                break
+            page += 1
+
+        return comments_text
+
+    for repo in repos.split(","):
+        repo = repo.strip()
+        if "/" not in repo:
+            print(f"Skipping invalid repo format: {repo}")
+            continue
+
+        owner, name = repo.split("/", 1)
+        print(f"Fetching issues from {owner}/{name}...")
+
+        page = 1
+        repo_issues = []
+
+        while len(repo_issues) < max_issues_per_repo:
+            url = f"https://api.github.com/repos/{owner}/{name}/issues"
+            params = {
+                "state": state,
+                "labels": labels,
+                "per_page": 100,
+                "page": page
+            }
+
+            issues = api_request(url, params)
+            if not issues:
+                break
+
+            for issue in issues:
+                if "pull_request" in issue:
+                    continue
+
+                labels_str = ", ".join([l["name"] for l in issue.get("labels", [])])
+                issue_url = issue.get("html_url", "")
+                created_at = issue.get("created_at", "")[:10]
+                updated_at = issue.get("updated_at", "")[:10]
+
+                # Build issue content with full metadata
+                content = f"# {issue['title']}\n\n"
+                content += f"**Repository:** {repo}\n"
+                content += f"**Issue:** #{issue['number']}\n"
+                content += f"**URL:** {issue_url}\n"
+                content += f"**Labels:** {labels_str}\n"
+                content += f"**State:** {issue['state']}\n"
+                content += f"**Created:** {created_at}\n"
+                content += f"**Updated:** {updated_at}\n\n"
+                content += issue.get("body", "") or ""
+
+                # Fetch and append comments
+                if issue.get("comments", 0) > 0:
+                    comments = fetch_comments(owner, name, issue["number"])
+                    content += comments
+
+                repo_issues.append({
+                    "path": f"issues/{name}/{issue['number']}",
+                    "content": content,
+                    "file_name": f"issue-{name}-{issue['number']}.md",
+                    "url": issue_url
+                })
+
+                if len(repo_issues) >= max_issues_per_repo:
+                    break
+
+            page += 1
+
+        all_issues.extend(repo_issues)
+        print(f"  Fetched {len(repo_issues)} issues from {repo}")
+
+    print(f"Total issues fetched: {len(all_issues)}")
+
+    with open(issues_data.path, 'w', encoding='utf-8') as f:
+        for issue_data in all_issues:
+            f.write(json.dumps(issue_data, ensure_ascii=False) + '\n')
+
+
+@dsl.component(
+    base_image="pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime",
+    packages_to_install=["sentence-transformers", "langchain"]
+)
+def chunk_and_embed_issues(
+    issues_data: dsl.Input[dsl.Dataset],
+    chunk_size: int,
+    chunk_overlap: int,
+    embedded_data: dsl.Output[dsl.Dataset]
+):
+    """Chunk GitHub issues at comment boundaries and generate embeddings.
+
+    Chunking strategy:
+    - Parse metadata (repo, issue number, state, labels, URL) from content
+    - Prepend a metadata prefix to every chunk for self-contained retrieval
+    - Split at comment boundaries (--- separators) first
+    - Subdivide oversized segments with RecursiveCharacterTextSplitter
+    - Short issues (body + comments < chunk_size) become a single chunk
+    """
+    import json
+    import re
+    import torch
+    from sentence_transformers import SentenceTransformer
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = SentenceTransformer('sentence-transformers/all-mpnet-base-v2', device=device)
+    print(f"Model loaded on {device}")
+
+    def parse_metadata(content):
+        """Extract structured metadata from issue content."""
+        title_match = re.search(r'^#\s+(.+)', content, re.MULTILINE)
+        repo_match = re.search(r'\*\*Repository:\*\*\s*(.+)', content)
+        number_match = re.search(r'\*\*Issue:\*\*\s*#(\d+)', content)
+        url_match = re.search(r'\*\*URL:\*\*\s*(.+)', content)
+        labels_match = re.search(r'\*\*Labels:\*\*[ \t]*(.*)', content)
+        state_match = re.search(r'\*\*State:\*\*\s*(\w+)', content)
+        return {
+            "title": title_match.group(1).strip() if title_match else "",
+            "repo_name": repo_match.group(1).strip() if repo_match else "",
+            "issue_number": int(number_match.group(1)) if number_match else 0,
+            "issue_state": state_match.group(1).strip() if state_match else "",
+            "issue_labels": labels_match.group(1).strip() if labels_match else "",
+            "citation_url": url_match.group(1).strip() if url_match else "",
+        }
+
+    def build_prefix(meta):
+        """Build metadata prefix for each chunk."""
+        parts = [f"[Issue #{meta['issue_number']}] {meta['title']}"]
+        if meta["repo_name"]:
+            parts.append(f"Repo: {meta['repo_name']}")
+        if meta["issue_state"]:
+            parts.append(f"State: {meta['issue_state']}")
+        if meta["issue_labels"]:
+            parts.append(f"Labels: {meta['issue_labels']}")
+        return " | ".join(parts) + "\n\n"
+
+    records = []
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    with open(issues_data.path, 'r', encoding='utf-8') as f:
+        for line in f:
+            issue = json.loads(line)
+            content = issue["content"]
+            metadata = parse_metadata(content)
+            prefix = build_prefix(metadata)
+            effective_size = chunk_size - len(prefix)
+            if effective_size < 100:
+                effective_size = 100
+
+            # Split at comment boundaries or keep as single chunk
+            if len(content) <= effective_size:
+                chunks = [prefix + content]
+            else:
+                segments = re.split(r'\n\n---\n', content)
+                chunks = []
+                for segment in segments:
+                    segment = segment.strip()
+                    if not segment:
+                        continue
+                    if len(segment) <= effective_size:
+                        chunks.append(prefix + segment)
+                    else:
+                        for sub in splitter.split_text(segment):
+                            chunks.append(prefix + sub)
+                if not chunks:
+                    chunks = [prefix + content[:effective_size]]
+
+            # Embed and create records
+            for chunk_idx, chunk_text in enumerate(chunks):
+                embedding = model.encode(chunk_text).tolist()
+                records.append({
+                    "file_unique_id": f"{metadata['repo_name']}:issues/{metadata['issue_number']}",
+                    "repo_name": metadata["repo_name"],
+                    "issue_number": metadata["issue_number"],
+                    "issue_state": metadata["issue_state"],
+                    "issue_labels": metadata["issue_labels"],
+                    "citation_url": metadata["citation_url"],
+                    "chunk_index": chunk_idx,
+                    "content_text": chunk_text[:2000],
+                    "embedding": embedding,
+                    "source_type": "issue",
+                })
+
+            print(f"Issue #{metadata['issue_number']}: {len(chunks)} chunks")
+
+    print(f"Total chunks: {len(records)}")
+
+    with open(embedded_data.path, 'w', encoding='utf-8') as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+
+@dsl.component(
+    base_image="python:3.9",
+    packages_to_install=["pymilvus", "numpy"]
+)
+def store_issues_milvus(
+    embedded_data: dsl.Input[dsl.Dataset],
+    milvus_host: str,
+    milvus_port: str,
+    collection_name: str
+):
+    """Store issue embeddings in a dedicated Milvus collection.
+
+    Creates the issues_rag collection with issue-specific schema fields
+    (issue_number, issue_state, issue_labels, source_type).
+    """
+    from pymilvus import connections, utility, FieldSchema, CollectionSchema, DataType, Collection
+    import json
+    from datetime import datetime
+
+    connections.connect("default", host=milvus_host, port=milvus_port)
+
+    if utility.has_collection(collection_name):
+        utility.drop_collection(collection_name)
+        print(f"Dropped existing collection: {collection_name}")
+
+    fields = [
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+        FieldSchema(name="file_unique_id", dtype=DataType.VARCHAR, max_length=512),
+        FieldSchema(name="repo_name", dtype=DataType.VARCHAR, max_length=256),
+        FieldSchema(name="issue_number", dtype=DataType.INT64),
+        FieldSchema(name="issue_state", dtype=DataType.VARCHAR, max_length=32),
+        FieldSchema(name="issue_labels", dtype=DataType.VARCHAR, max_length=1024),
+        FieldSchema(name="citation_url", dtype=DataType.VARCHAR, max_length=1024),
+        FieldSchema(name="chunk_index", dtype=DataType.INT64),
+        FieldSchema(name="content_text", dtype=DataType.VARCHAR, max_length=2000),
+        FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=768),
+        FieldSchema(name="last_updated", dtype=DataType.INT64),
+        FieldSchema(name="source_type", dtype=DataType.VARCHAR, max_length=64),
+    ]
+
+    schema = CollectionSchema(fields, "RAG collection for GitHub issues")
+    collection = Collection(collection_name, schema)
+    print(f"Created collection: {collection_name}")
+
+    records = []
+    timestamp = int(datetime.now().timestamp())
+
+    with open(embedded_data.path, 'r', encoding='utf-8') as f:
+        for line in f:
+            record = json.loads(line)
+            records.append({
+                "file_unique_id": record["file_unique_id"],
+                "repo_name": record["repo_name"],
+                "issue_number": record["issue_number"],
+                "issue_state": record["issue_state"],
+                "issue_labels": record["issue_labels"],
+                "citation_url": record["citation_url"],
+                "chunk_index": record["chunk_index"],
+                "content_text": record["content_text"],
+                "vector": record["embedding"],
+                "last_updated": timestamp,
+                "source_type": record["source_type"],
+            })
+
+    if records:
+        batch_size = 1000
+        for i in range(0, len(records), batch_size):
+            batch = records[i:i + batch_size]
+            collection.insert(batch)
+
+        collection.flush()
+
+        index_params = {
+            "metric_type": "COSINE",
+            "index_type": "IVF_FLAT",
+            "params": {"nlist": min(1024, len(records))}
+        }
+        collection.create_index("vector", index_params)
+        collection.load()
+        print(f"Inserted {len(records)} records. Total: {collection.num_entities}")
+
+
+@dsl.pipeline(
+    name="github-issues-rag",
+    description="RAG pipeline for GitHub issues ingestion"
+)
+def github_issues_rag_pipeline(
+    repos: str = "kubeflow/kubeflow,kubeflow/pipelines,kubeflow/manifests",
+    labels: str = "",
+    state: str = "all",
+    max_issues_per_repo: int = 200,
+    github_token: str = "",
+    chunk_size: int = 1500,
+    chunk_overlap: int = 150,
+    milvus_host: str = "my-release-milvus.docs-agent.svc.cluster.local",
+    milvus_port: str = "19530",
+    collection_name: str = "issues_rag"
+):
+    download_task = download_github_issues(
+        repos=repos,
+        labels=labels,
+        state=state,
+        max_issues_per_repo=max_issues_per_repo,
+        github_token=github_token,
+    )
+
+    chunk_task = chunk_and_embed_issues(
+        issues_data=download_task.outputs["issues_data"],
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+
+    store_issues_milvus(
+        embedded_data=chunk_task.outputs["embedded_data"],
+        milvus_host=milvus_host,
+        milvus_port=milvus_port,
+        collection_name=collection_name,
+    )
+
+
+if __name__ == "__main__":
+    import os
+    os.environ['KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT'] = 'true'
+    kfp.compiler.Compiler().compile(
+        pipeline_func=github_issues_rag_pipeline,
+        package_path="github_issues_rag_pipeline.yaml"
+    )
+    print("Compiled: github_issues_rag_pipeline.yaml")

--- a/pipelines/issues_utils.py
+++ b/pipelines/issues_utils.py
@@ -1,0 +1,113 @@
+"""Utility functions for GitHub issues pipeline chunking and metadata extraction."""
+
+import re
+
+
+def parse_issue_metadata(content: str) -> dict:
+    """Extract structured metadata from download_github_issues output format.
+
+    The content follows the format produced by the download_github_issues
+    KFP component: title line, metadata lines, body, and comments.
+
+    Args:
+        content: Raw issue content string from download_github_issues.
+
+    Returns:
+        Dict with keys: title, repo_name, issue_number, issue_state,
+        issue_labels, citation_url. Missing fields default to empty string
+        (or 0 for issue_number).
+    """
+    title_match = re.search(r'^#\s+(.+)', content, re.MULTILINE)
+    repo_match = re.search(r'\*\*Repository:\*\*\s*(.+)', content)
+    number_match = re.search(r'\*\*Issue:\*\*\s*#(\d+)', content)
+    url_match = re.search(r'\*\*URL:\*\*\s*(.+)', content)
+    labels_match = re.search(r'\*\*Labels:\*\*[ \t]*(.*)', content)
+    state_match = re.search(r'\*\*State:\*\*\s*(\w+)', content)
+
+    return {
+        "title": title_match.group(1).strip() if title_match else "",
+        "repo_name": repo_match.group(1).strip() if repo_match else "",
+        "issue_number": int(number_match.group(1)) if number_match else 0,
+        "issue_state": state_match.group(1).strip() if state_match else "",
+        "issue_labels": labels_match.group(1).strip() if labels_match else "",
+        "citation_url": url_match.group(1).strip() if url_match else "",
+    }
+
+
+def build_metadata_prefix(metadata: dict) -> str:
+    """Build a self-contained prefix string for each chunk.
+
+    Args:
+        metadata: Dict from parse_issue_metadata.
+
+    Returns:
+        Prefix string like "[Issue #42] Title | Repo: x | State: open | Labels: y"
+    """
+    parts = [f"[Issue #{metadata['issue_number']}] {metadata['title']}"]
+    if metadata["repo_name"]:
+        parts.append(f"Repo: {metadata['repo_name']}")
+    if metadata["issue_state"]:
+        parts.append(f"State: {metadata['issue_state']}")
+    if metadata["issue_labels"]:
+        parts.append(f"Labels: {metadata['issue_labels']}")
+    return " | ".join(parts) + "\n\n"
+
+
+def split_issue_into_chunks(
+    content: str,
+    metadata_prefix: str,
+    chunk_size: int = 1500,
+    chunk_overlap: int = 150,
+) -> list[str]:
+    """Split issue content into chunks at comment boundaries.
+
+    Strategy:
+    - Split at '\\n\\n---\\n' boundaries (comment separators from download_github_issues)
+    - If entire content fits in one chunk, return single chunk
+    - If a segment exceeds chunk_size, subdivide with RecursiveCharacterTextSplitter
+    - Prepend metadata_prefix to every chunk
+
+    Args:
+        content: Full issue content string.
+        metadata_prefix: Prefix to prepend to each chunk.
+        chunk_size: Maximum chunk size in characters.
+        chunk_overlap: Overlap between subdivided chunks.
+
+    Returns:
+        List of chunk strings, each prefixed with metadata.
+    """
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+    # Available space for content after prefix
+    effective_size = chunk_size - len(metadata_prefix)
+    if effective_size < 100:
+        effective_size = 100
+
+    # If entire content fits, return single chunk
+    if len(content) <= effective_size:
+        return [metadata_prefix + content]
+
+    # Split at comment boundaries
+    segments = re.split(r'\n\n---\n', content)
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=effective_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    chunks = []
+    for segment in segments:
+        segment = segment.strip()
+        if not segment:
+            continue
+        if len(segment) <= effective_size:
+            chunks.append(metadata_prefix + segment)
+        else:
+            # Subdivide oversized segment
+            sub_chunks = splitter.split_text(segment)
+            for sub in sub_chunks:
+                chunks.append(metadata_prefix + sub)
+
+    return chunks if chunks else [metadata_prefix + content[:effective_size]]

--- a/scripts/index_real_issues.py
+++ b/scripts/index_real_issues.py
@@ -1,0 +1,319 @@
+"""Fetch real GitHub issues, chunk, embed, and index into Milvus.
+
+This script implements the issues ingestion pipeline end-to-end:
+  1. Fetch issues from kubeflow repos via GitHub API
+  2. Chunk using comment-boundary-aware splitting (issues_utils)
+  3. Embed with sentence-transformers/all-mpnet-base-v2
+  4. Store into issues_rag Milvus collection
+
+Usage:
+    # Port-forward first: kubectl port-forward svc/my-release-milvus -n docs-agent 19530:19530
+    python scripts/index_real_issues.py [--max-issues 50] [--repos kubeflow/kubeflow,kubeflow/pipelines]
+
+Set GITHUB_TOKEN env var for higher rate limits.
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+
+import requests
+from pymilvus import (
+    Collection,
+    CollectionSchema,
+    DataType,
+    FieldSchema,
+    connections,
+    utility,
+)
+from sentence_transformers import SentenceTransformer
+
+# Add pipelines to path for issues_utils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "pipelines"))
+from issues_utils import build_metadata_prefix, parse_issue_metadata, split_issue_into_chunks
+
+MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")
+MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+COLLECTION_NAME = "issues_rag"
+EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
+
+DEFAULT_REPOS = [
+    "kubeflow/kubeflow",
+    "kubeflow/pipelines",
+    "kubeflow/manifests",
+    "kubeflow/katib",
+]
+
+GITHUB_API = "https://api.github.com"
+
+
+def fetch_issues(repo: str, max_issues: int, token: str | None) -> list[dict]:
+    """Fetch issues from a GitHub repo (excludes pull requests)."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    issues = []
+    page = 1
+    per_page = min(max_issues, 100)
+
+    while len(issues) < max_issues:
+        url = f"{GITHUB_API}/repos/{repo}/issues"
+        params = {
+            "state": "all",
+            "per_page": per_page,
+            "page": page,
+            "sort": "updated",
+            "direction": "desc",
+        }
+        resp = requests.get(url, headers=headers, params=params, timeout=30)
+
+        if resp.status_code == 403:
+            reset = int(resp.headers.get("X-RateLimit-Reset", 0))
+            wait = max(reset - int(time.time()), 10)
+            print(f"  Rate limited, waiting {wait}s...")
+            time.sleep(wait)
+            continue
+
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+
+        for item in batch:
+            if "pull_request" in item:
+                continue  # Skip PRs
+            if len(issues) >= max_issues:
+                break
+            issues.append(item)
+
+        page += 1
+
+    return issues
+
+
+def format_issue_content(issue: dict, repo: str, comments: list[dict]) -> str:
+    """Format a GitHub issue into the download_github_issues output format."""
+    labels = ", ".join(l["name"] for l in issue.get("labels", []))
+    state = issue["state"]
+
+    lines = [
+        f"# {issue['title']}",
+        f"**Repository:** {repo}",
+        f"**Issue:** #{issue['number']}",
+        f"**State:** {state}",
+        f"**Labels:** {labels}",
+        f"**URL:** {issue['html_url']}",
+        "",
+        issue.get("body") or "(no description)",
+    ]
+
+    for c in comments:
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+        lines.append(f"**Comment by {c['user']['login']}** ({c['created_at'][:10]}):")
+        lines.append(c.get("body") or "")
+
+    return "\n".join(lines)
+
+
+def fetch_comments(repo: str, issue_number: int, token: str | None) -> list[dict]:
+    """Fetch comments for a specific issue."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}/comments"
+    resp = requests.get(url, headers=headers, params={"per_page": 30}, timeout=30)
+
+    if resp.status_code == 403:
+        return []  # Skip on rate limit
+
+    resp.raise_for_status()
+    return resp.json()
+
+
+COLLECTION_FIELDS = [
+    FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+    FieldSchema(name="file_unique_id", dtype=DataType.VARCHAR, max_length=512),
+    FieldSchema(name="repo_name", dtype=DataType.VARCHAR, max_length=256),
+    FieldSchema(name="issue_number", dtype=DataType.INT64),
+    FieldSchema(name="issue_state", dtype=DataType.VARCHAR, max_length=32),
+    FieldSchema(name="issue_labels", dtype=DataType.VARCHAR, max_length=1024),
+    FieldSchema(name="citation_url", dtype=DataType.VARCHAR, max_length=1024),
+    FieldSchema(name="chunk_index", dtype=DataType.INT64),
+    FieldSchema(name="content_text", dtype=DataType.VARCHAR, max_length=2000),
+    FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=768),
+    FieldSchema(name="last_updated", dtype=DataType.INT64),
+    FieldSchema(name="source_type", dtype=DataType.VARCHAR, max_length=64),
+]
+
+
+def ensure_collection(fresh: bool = False) -> Collection:
+    """Create or get the issues_rag collection.
+
+    Args:
+        fresh: If True, drop and recreate. If False (default), reuse existing.
+    """
+    if utility.has_collection(COLLECTION_NAME):
+        if fresh:
+            utility.drop_collection(COLLECTION_NAME)
+            print(f"Dropped existing {COLLECTION_NAME}")
+        else:
+            print(f"Reusing existing {COLLECTION_NAME} (incremental mode)")
+            col = Collection(COLLECTION_NAME)
+            # Ensure index exists before loading
+            if not col.has_index():
+                print("  Creating missing index...")
+                col.create_index("vector", {
+                    "metric_type": "COSINE",
+                    "index_type": "IVF_FLAT",
+                    "params": {"nlist": min(1024, max(1, col.num_entities))},
+                })
+            col.load()
+            return col
+
+    schema = CollectionSchema(COLLECTION_FIELDS, "RAG collection for GitHub issues")
+    collection = Collection(COLLECTION_NAME, schema)
+    print(f"Created collection: {COLLECTION_NAME}")
+    return collection
+
+
+def get_indexed_issue_ids(collection: Collection, repo: str) -> set[int]:
+    """Return set of issue_numbers already indexed for a given repo."""
+    try:
+        results = collection.query(
+            expr=f'repo_name == "{repo}"',
+            output_fields=["issue_number"],
+            limit=16384,
+        )
+        return {r["issue_number"] for r in results}
+    except Exception:
+        return set()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Index real GitHub issues into Milvus")
+    parser.add_argument("--max-issues", type=int, default=25, help="Max issues per repo")
+    parser.add_argument("--repos", type=str, default=",".join(DEFAULT_REPOS))
+    parser.add_argument("--fresh", action="store_true",
+                        help="Drop and recreate collection (default: incremental)")
+    args = parser.parse_args()
+
+    repos = [r.strip() for r in args.repos.split(",")]
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("WARNING: No GITHUB_TOKEN set. Rate limits will be very low (60 req/hr).")
+
+    # Connect to Milvus
+    print("Connecting to Milvus...")
+    connections.connect("default", host=MILVUS_HOST, port=MILVUS_PORT)
+
+    # Load embedding model
+    print("Loading embedding model...")
+    model = SentenceTransformer(EMBEDDING_MODEL)
+
+    # Create or reuse collection
+    collection = ensure_collection(fresh=args.fresh)
+
+    timestamp = int(time.time())
+    total_chunks = 0
+
+    for repo in repos:
+        print(f"\n{'='*60}")
+        print(f"Fetching issues from {repo}...")
+
+        # In incremental mode, skip already-indexed issues
+        existing_ids = set()
+        if not args.fresh:
+            existing_ids = get_indexed_issue_ids(collection, repo)
+            if existing_ids:
+                print(f"  Already indexed: {len(existing_ids)} issues")
+
+        issues = fetch_issues(repo, args.max_issues, token)
+        # Filter out already-indexed issues
+        issues = [i for i in issues if i["number"] not in existing_ids]
+        print(f"  Got {len(issues)} new issues to index")
+
+        records = []
+        for issue in issues:
+            # Fetch comments
+            comments = fetch_comments(repo, issue["number"], token)
+
+            # Format into pipeline output format
+            content = format_issue_content(issue, repo, comments)
+
+            # Parse metadata and chunk using pipeline utilities
+            metadata = parse_issue_metadata(content)
+            prefix = build_metadata_prefix(metadata)
+            chunks = split_issue_into_chunks(content, prefix, chunk_size=1500, chunk_overlap=150)
+
+            labels = ", ".join(l["name"] for l in issue.get("labels", []))
+
+            for idx, chunk in enumerate(chunks):
+                # Truncate to fit VARCHAR(2000)
+                chunk_text = chunk[:2000]
+                embedding = model.encode(chunk_text).tolist()
+
+                records.append({
+                    "file_unique_id": f"{repo}:issues/{issue['number']}",
+                    "repo_name": repo,
+                    "issue_number": issue["number"],
+                    "issue_state": issue["state"],
+                    "issue_labels": labels[:1024],
+                    "citation_url": issue["html_url"],
+                    "chunk_index": idx,
+                    "content_text": chunk_text,
+                    "vector": embedding,
+                    "last_updated": timestamp,
+                    "source_type": "issue",
+                })
+
+            total_chunks += len(chunks)
+            print(f"  #{issue['number']}: {issue['title'][:60]} ({len(chunks)} chunks, {len(comments)} comments)")
+
+        if records:
+            # Insert in batches of 100
+            for i in range(0, len(records), 100):
+                batch = records[i:i+100]
+                collection.insert(batch)
+            print(f"  Inserted {len(records)} records from {repo}")
+
+    collection.flush()
+
+    # Create index if needed (fresh mode or first run)
+    if not collection.has_index():
+        print("\nCreating vector index...")
+        index_params = {
+            "metric_type": "COSINE",
+            "index_type": "IVF_FLAT",
+            "params": {"nlist": min(1024, max(1, collection.num_entities))},
+        }
+        collection.create_index("vector", index_params)
+    collection.load()
+
+    print(f"\nTotal: {collection.num_entities} chunks from {len(repos)} repos")
+
+    # Sanity search
+    print("\n--- Sanity check: 'pipeline timeout error' ---")
+    q_emb = model.encode("pipeline timeout error").tolist()
+    results = collection.search(
+        data=[q_emb],
+        anns_field="vector",
+        param={"metric_type": "COSINE", "params": {"nprobe": 10}},
+        limit=3,
+        output_fields=["issue_number", "repo_name", "issue_state", "content_text"],
+    )
+    for hits in results:
+        for hit in hits:
+            print(f"  #{hit.entity.get('issue_number')} [{hit.entity.get('repo_name')}] "
+                  f"(score: {hit.distance:.4f}): {hit.entity.get('content_text', '')[:80]}...")
+
+    print("\nDone! issues_rag is ready for search_github_issues MCP tool.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `search_github_issues` MCP tool for semantic search across Kubeflow GitHub issues (kubeflow/kubeflow, kubeflow/pipelines, kubeflow/manifests, kubeflow/katib, kserve/kserve, kubeflow/website)
- Extract shared `_search_collection` helper in MCP server to reduce duplication between docs and issues search
- Add KFP pipeline (`issues-pipeline.py`) with comment-boundary-aware chunking for GitHub issues ingestion
- Add standalone indexing script (`index_real_issues.py`) with incremental mode support
- Update kagent Agent CRD with two-tool routing system prompt

## Details

### MCP Server (`server.py`)
- New `search_github_issues` tool searches the `issues_rag` Milvus collection
- Returns issue content with metadata: repo name, issue number, state, labels, and GitHub URL
- Shared `_search_collection` helper eliminates code duplication

### Issues Pipeline (`pipelines/`)
- `issues-pipeline.py`: KFP pipeline with `download_github_issues`, `chunk_and_embed_issues`, `store_issues_milvus` components
- `issues_utils.py`: Utility functions for parsing issue metadata, building prefixes, and smart chunking at comment boundaries (`\n\n---\n`)

### Indexing Script (`scripts/index_real_issues.py`)
- Fetches real GitHub issues via API, chunks with issues_utils, embeds with sentence-transformers, stores in Milvus
- Supports incremental mode (default) — queries existing issue numbers per repo to avoid duplicates
- `--fresh` flag for full re-index

### Agent CRD (`setup.yaml`)
- Adds `search_github_issues` to agent toolNames
- Updated system prompt with two-tool routing: docs for "how to" questions, issues for error/bug troubleshooting

## Test plan
- [x] Tested live on OCI cluster with 1,631 real issue chunks indexed across 6 repos
- [x] Verified semantic search returns relevant results (e.g., "KServe model 404 error" → correct issue)
- [x] Confirmed agent correctly routes between docs and issues tools
- [ ] Unit tests for `issues_utils.py` chunking logic (planned for test-infrastructure branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)