### PR TITLE
fix(chatbot): match SSE event type to server's 'done' signal

### DIFF
--- a/docs_scripts/chatbot.js
+++ b/docs_scripts/chatbot.js
@@ -623,7 +623,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
         
         // Handle end of message or errors
-        if (response.type === 'end') {
+        if (response.type === 'done') {
             // Store the complete bot response in conversation history
             if (currentMessageContent.trim()) {
                 messagesHistory.push({


### PR DESCRIPTION
  ## Summary                                                                                                        
                                                                                                                  
  - The chat frontend (`docs_scripts/chatbot.js`) listens for `response.type === 'end'` to detect stream completion
  - Both servers emit `type: 'done'`:
    - `server-https/app.py:308` → `{'type': 'done'}`
    - `server/app.py:373` → `{"type": "done"}`
  - This mismatch means the frontend **never** detects stream completion, so:
    - The assistant's response is not saved to `messagesHistory`
    - `currentMessageDiv` and `currentMessageContent` are never reset
    - `autoSaveCurrentChat()` is never called at the end of a response

  ## Fix

  Changed `chatbot.js:626` from `response.type === 'end'` to `response.type === 'done'`.
