### PR TITLE
Preserve newlines in markdown cleaning for Langchain chunking

### DIFF
--- a/pipelines/incremental-pipeline.py
+++ b/pipelines/incremental-pipeline.py
@@ -187,9 +187,9 @@ def chunk_and_embed_incremental(
             content = re.sub(r'https?://[^\s]+', '', content)
             content = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', content)  # Convert [text](url) to text
 
-            # Remove excessive whitespace and normalize
-            content = re.sub(r'\s+', ' ', content)  # Multiple spaces to single
-            content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)  # Multiple newlines to double
+            # Remove excessive spaces/tabs and normalize
+            content = re.sub(r'[ \t]+', ' ', content)  # Multiple spaces/tabs to single
+            content = re.sub(r'\n\s*\n+', '\n\n', content)  # Consolidate multiple newlines
             content = content.strip()
 
             # Skip files that are too short after cleaning

--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -262,9 +262,9 @@ def chunk_and_embed(
             content = re.sub(r'https?://[^\s]+', '', content)
             content = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', content)  # Convert [text](url) to text
 
-            # Remove excessive whitespace and normalize
-            content = re.sub(r'\s+', ' ', content)  # Multiple spaces to single
-            content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)  # Multiple newlines to double
+            # Remove excessive spaces/tabs and normalize
+            content = re.sub(r'[ \t]+', ' ', content)  # Multiple spaces/tabs to single
+            content = re.sub(r'\n\s*\n+', '\n\n', content)  # Consolidate multiple newlines
             content = content.strip()
 
             # Skip files that are too short after cleaning


### PR DESCRIPTION
**What this PR does:**
This fixes a critical bug in the data ingestion pipelines where the `\s+` regex was unintentionally matching and destroying all newline characters (`\n`). 

**Why it matters:**
By flattening the entire Markdown document into a single line, the Langchain `RecursiveCharacterTextSplitter` was unable to split chunks by `\n\n`. This forced the chunker to arbitrarily slice text by character limits, severing semantic paragraphs and code blocks, which severely degrades the vector embeddings' retrieval quality.

**Changes:**
Updated the regex in both `kubeflow-pipeline.py` and `incremental-pipeline.py` to target only spaces and tabs (`[ \t]+`), successfully preserving paragraph boundaries for the text splitter.