### PR TITLE
fix(pipelines): guard against ZeroDivisionError when chunk list is empty

### DIFF
--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -295,6 +295,15 @@ def chunk_and_embed(
             # Split into chunks
             chunks = text_splitter.split_text(content)
 
+            # Guard: skip files that produce no chunks after splitting to
+            # avoid ZeroDivisionError in the log statement below.
+            # This can happen when content passes the < 50 char check but
+            # is reduced to nothing by the RecursiveCharacterTextSplitter
+            # (e.g. chunk_size larger than remaining content).
+            if not chunks:
+                print(f"Skipping file after chunking (no chunks produced): {file_data['path']}")
+                continue
+
             print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {sum(len(c) for c in chunks)/len(chunks):.0f} chars)")
 
             # Create embeddings


### PR DESCRIPTION
## Summary

Fixes #148

The `chunk_and_embed` component in `pipelines/kubeflow-pipeline.py` 
crashes with a `ZeroDivisionError` when `RecursiveCharacterTextSplitter` 
returns an empty chunk list.

## Root Cause

The pipeline already guards against short content with a `< 50` character 
check. However, a document can pass that guard and still produce zero 
chunks if:
- The `chunk_size` parameter is larger than the remaining content after 
  splitting
- The content is entirely composed of separators with no actual text

When `chunks = []`, the very next line divides by `len(chunks)` which 
is `0`, crashing the entire KFP component and failing the pipeline run.

## Fix

Added an explicit empty-chunk guard immediately after the splitter call,
consistent with the existing short-content guard pattern already in the
code:
```python
if not chunks:
    print(f"Skipping file after chunking (no chunks produced): {file_data['path']}")
    continue
```

## Testing

Verified the fix by manually passing an empty list through the affected
code path — the guard correctly skips the file and the pipeline
continues processing remaining documents without crashing.

## Checklist
- [x] Commits are signed off (DCO)
- [x] Fixes #148
- [x] No regressions to existing pipeline logic