### PR TITLE
fix(server-https): pass citations_collector into recursive stream_llm_response calls to prevent citation loss

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -194,9 +194,10 @@ async def execute_tool(tool_call: Dict[str, Any]) -> tuple[str, List[str]]:
         print(f"[ERROR] Tool execution failed: {e}")
         return f"Tool execution failed: {e}", []
 
-async def stream_llm_response(payload: Dict[str, Any]) -> AsyncGenerator[str, None]:
+async def stream_llm_response(payload: Dict[str, Any], citations_collector: List[str] = None) -> AsyncGenerator[str, None]:
     """Stream response from LLM and handle tool calls, yielding SSE events"""
-    citations_collector = []
+    if citations_collector is None:
+        citations_collector = []
     
     try:
         async with httpx.AsyncClient(timeout=120) as client:
@@ -341,7 +342,7 @@ async def handle_tool_follow_up(original_payload: Dict[str, Any], tool_call: Dic
         }
         
         # Stream the follow-up response
-        async for chunk in stream_llm_response(follow_up_payload):
+        async for chunk in stream_llm_response(follow_up_payload, citations_collector=citations_collector):
             yield chunk
         
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes #154

Citations collected during follow-up tool calls were silently discarded and never returned to the client in multi-hop agentic queries.

## Root Cause

`stream_llm_response` initialized a fresh `citations_collector = []` on every invocation:
```python
async def stream_llm_response(payload, ...):
    citations_collector = []  # new list on every call
```

When `handle_tool_follow_up` called `stream_llm_response` recursively, the inner call created its own isolated list. Citations found during that inner call were collected correctly — but discarded when the inner call returned. Only the outermost call's citations ever reached the client.

## Failure Scenario

1. User asks a multi-hop Kubeflow question
2. Agent calls `search_kubeflow_docs` → 3 citations in outer list ✅
3. Agent calls `search_kubeflow_docs` again in follow-up → citations collected in **inner** list ❌
4. Inner list discarded on return
5. Client receives only citations from step 2

## Fix

Accept `citations_collector` as an optional parameter, defaulting to a new list only at the outermost call. All recursive invocations now share the same list:
```python
async def stream_llm_response(payload, citations_collector: List[str] = None):
    if citations_collector is None:
        citations_collector = []
```

The shared list is passed through to every recursive call:
```python
async for chunk in stream_llm_response(follow_up_payload, citations_collector=citations_collector):
    yield chunk
```

## Testing

Verified that a two-hop query now returns citations from both tool call hops instead of only the first.

## Checklist
- [x] Commits are signed off (DCO)
- [x] Fixes #154
- [x] No regressions to single-turn query paths
- [x] Outermost call behaviour unchanged — new list created only once