### PR TITLE
fix(pipelines): guard against ZeroDivisionError in chunk_and_embed_incremental when chunk list is empty

### DIFF
--- a/pipelines/incremental-pipeline.py
+++ b/pipelines/incremental-pipeline.py
@@ -220,6 +220,13 @@ def chunk_and_embed_incremental(
             # Split into chunks
             chunks = text_splitter.split_text(content)
 
+            # Guard: skip files that produce no chunks after splitting to
+            # avoid ZeroDivisionError in the log statement below.
+            # Same fix as kubeflow-pipeline.py (PR #149, issue #148).
+            if not chunks:
+                print(f"Skipping file after chunking (no chunks produced): {file_data['path']}")
+                continue
+
             print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {sum(len(c) for c in chunks)/len(chunks):.0f} chars)")
 
             # Create embeddings


### PR DESCRIPTION
## Summary

Fixes #163

`chunk_and_embed_incremental` in `pipelines/incremental-pipeline.py` has the same `ZeroDivisionError` crash as `kubeflow-pipeline.py`, fixed in PR #149 (issue #148) — but the incremental pipeline was not addressed by that fix.

## Root Cause

The incremental pipeline applies identical aggressive regex cleaning (Hugo frontmatter, HTML tags, URLs). A document can pass the `< 50` char content guard but produce zero chunks after splitting. The print statement on the next line divides by `len(chunks) == 0`, crashing the entire incremental KFP run.

## Affected Line
```python
print(f"File: {file_data['path']} -> {len(chunks)} chunks (avg: {sum(len(c) for c in chunks)/len(chunks):.0f} chars)")
```

## Fix

Added the same empty-chunk guard already applied in PR #149:
```python
if not chunks:
    print(f"Skipping file after chunking (no chunks produced): {file_data['path']}")
    continue
```

## Checklist
- [x] Commits are signed off (DCO)
- [x] Fixes #163
- [x] Consistent with fix already applied in PR #149
- [x] No regressions to incremental pipeline logic