### PR TITLE
feat(pipelines): integrate GitHub issues ingestion into RAG pipeline

### DIFF
--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -230,7 +230,7 @@ def chunk_and_embed(
     import re
     import torch
     from sentence_transformers import SentenceTransformer
-    from langchain.text_splitter import RecursiveCharacterTextSplitter
+    from langchain_text_splitter import RecursiveCharacterTextSplitter
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     model = SentenceTransformer('sentence-transformers/all-mpnet-base-v2', device=device)
@@ -420,6 +420,13 @@ def github_rag_pipeline(
         github_token=github_token
     )
     
+    issues_task = download_github_issues(
+    repos="kubeflow/kubeflow,kubeflow/pipelines",
+    labels="",
+    state="open",
+    max_issues_per_repo=50,
+    github_token=github_token
+    )
     # Chunk and embed the content
     chunk_task = chunk_and_embed(
         github_data=download_task.outputs["github_data"],
@@ -428,7 +435,14 @@ def github_rag_pipeline(
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap
     )
-    
+    issues_chunk_task = chunk_and_embed(
+    github_data=issues_task.outputs["issues_data"],
+    repo_name="kubeflow-issues",
+    base_url="https://github.com",
+    chunk_size=chunk_size,
+    chunk_overlap=chunk_overlap
+    )
+    issues_chunk_task.after(issues_task)
     # Store in Milvus
     store_task = store_milvus(
         embedded_data=chunk_task.outputs["embedded_data"],

--- a/pipelines/kubeflow-pipeline.py
+++ b/pipelines/kubeflow-pipeline.py
@@ -230,7 +230,7 @@ def chunk_and_embed(
     import re
     import torch
     from sentence_transformers import SentenceTransformer
-    from langchain_text_splitter import RecursiveCharacterTextSplitter
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     model = SentenceTransformer('sentence-transformers/all-mpnet-base-v2', device=device)
@@ -421,12 +421,23 @@ def github_rag_pipeline(
     )
     
     issues_task = download_github_issues(
-    repos="kubeflow/kubeflow,kubeflow/pipelines",
+    repos=f"{repo_owner}/{repo_name}",
     labels="",
     state="open",
     max_issues_per_repo=50,
     github_token=github_token
     )
+    
+    issues_chunk_task = chunk_and_embed(
+    github_data=issues_task.outputs["issues_data"],
+    repo_name="kubeflow-issues",
+    base_url="https://github.com",
+    chunk_size=chunk_size,
+    chunk_overlap=chunk_overlap
+    )
+    
+    issues_chunk_task.after(issues_task)
+    
     # Chunk and embed the content
     chunk_task = chunk_and_embed(
         github_data=download_task.outputs["github_data"],
@@ -435,14 +446,8 @@ def github_rag_pipeline(
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap
     )
-    issues_chunk_task = chunk_and_embed(
-    github_data=issues_task.outputs["issues_data"],
-    repo_name="kubeflow-issues",
-    base_url="https://github.com",
-    chunk_size=chunk_size,
-    chunk_overlap=chunk_overlap
-    )
-    issues_chunk_task.after(issues_task)
+    
+    
     # Store in Milvus
     store_task = store_milvus(
         embedded_data=chunk_task.outputs["embedded_data"],


### PR DESCRIPTION
## Summary

This PR adds a GitHub issues ingestion component to the Kubeflow-based RAG pipeline, enabling ingestion of issues and their comments as an additional knowledge source.

## Changes

* Added `download_github_issues` component to fetch issues and comments via the GitHub API
* Integrated the component into `github_rag_pipeline`
* Added a `chunk_and_embed` task for ingested issues data
* Ensured task dependency (`issues_chunk_task.after(issues_task)`) for correct execution order

## Scope

* This PR focuses only on adding GitHub issues ingestion
* No changes were made to existing chunking or embedding logic

## Why

Including GitHub issues improves RAG answer quality by incorporating real-world discussions, troubleshooting context, and community knowledge.

## Related Issue

Closes #9
