### PR TITLE
fix(mcp-server): use double-checked locking to prevent race condition in _init()

### DIFF
--- a/kagent-feast-mcp/mcp-server/server.py
+++ b/kagent-feast-mcp/mcp-server/server.py
@@ -1,3 +1,5 @@
+import threading
+
 from fastmcp import FastMCP
 from pymilvus import MilvusClient
 from sentence_transformers import SentenceTransformer
@@ -13,14 +15,18 @@ mcp = FastMCP("Kubeflow Docs MCP Server")
 
 model: SentenceTransformer = None
 client: MilvusClient = None
+_init_lock = threading.Lock()
 
 
 def _init():
+    """Initialize model and client using double-checked locking to prevent race conditions."""
     global model, client
-    if model is None:
-        model = SentenceTransformer(EMBEDDING_MODEL)
-    if client is None:
-        client = MilvusClient(uri=MILVUS_URI, user=MILVUS_USER, password=MILVUS_PASSWORD)
+    if model is None or client is None:
+        with _init_lock:
+            if model is None:
+                model = SentenceTransformer(EMBEDDING_MODEL)
+            if client is None:
+                client = MilvusClient(uri=MILVUS_URI, user=MILVUS_USER, password=MILVUS_PASSWORD)
 
 
 @mcp.tool()


### PR DESCRIPTION
Fixes #169

`_init()` checked `if model is None` without any synchronisation. Under concurrent tool calls, multiple threads could observe `model` as `None` simultaneously and each create a separate `SentenceTransformer`, wasting memory and causing non-deterministic initialisation behaviour.

## **Root Cause**

The check-then-act on the global has no lock. Two threads arriving before the first load completes both pass the `if model is None` guard and each run `SentenceTransformer(EMBEDDING_MODEL)`, doubling memory usage.

## **Fix**

Add a module-level `threading.Lock()` and apply double-checked locking: fast unsynchronised check on the hot path, safe initialisation under the lock. Only one thread ever runs the constructor.

## **Testing**

- [x]  Single-threaded path behaviour unchanged
- [x]  Concurrent calls can no longer double-initialise the model

## **Checklist**

- [x]  Commits are signed off (DCO)
- [x]  Fixes #169
- [x]  No behaviour change on single-threaded path
- [x]  Hardcoded credentials untouched (tracked separately in #91 / PR #135)