### PR TITLE
fix: cache SentenceTransformer model at startup instead of per-request

### DIFF
--- a/server-https/app.py
+++ b/server-https/app.py
@@ -22,6 +22,11 @@ MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
 MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
 
+# Initialize embedding model once at module level to avoid reloading on every request
+print(f"Loading embedding model: {EMBEDDING_MODEL}...")
+_embedding_model = SentenceTransformer(EMBEDDING_MODEL)
+print("Embedding model loaded successfully.")
+
 # System prompt (same as WebSocket version)
 SYSTEM_PROMPT = """
 You are the Kubeflow Docs Assistant.
@@ -119,9 +124,8 @@ def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
         collection = Collection(MILVUS_COLLECTION)
         collection.load()
 
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
+        # Encode query using cached model
+        query_vec = _embedding_model.encode(query).tolist()
 
         search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
         results = collection.search(

--- a/server/app.py
+++ b/server/app.py
@@ -22,6 +22,11 @@ MILVUS_COLLECTION = os.getenv("MILVUS_COLLECTION", "docs_rag")
 MILVUS_VECTOR_FIELD = os.getenv("MILVUS_VECTOR_FIELD", "vector")
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
 
+# Initialize embedding model once at module level to avoid reloading on every request
+print(f"Loading embedding model: {EMBEDDING_MODEL}...")
+_embedding_model = SentenceTransformer(EMBEDDING_MODEL)
+print("Embedding model loaded successfully.")
+
 # System prompt
 SYSTEM_PROMPT = """
 You are the Kubeflow Docs Assistant.
@@ -73,9 +78,8 @@ def milvus_search(query: str, top_k: int = 5) -> Dict[str, Any]:
         collection = Collection(MILVUS_COLLECTION)
         collection.load()
 
-        # Encoder (same model as pipeline)
-        encoder = SentenceTransformer(EMBEDDING_MODEL)
-        query_vec = encoder.encode(query).tolist()
+        # Encode query using cached model
+        query_vec = _embedding_model.encode(query).tolist()
 
         search_params = {"metric_type": "COSINE", "params": {"nprobe": 32}}
         results = collection.search(


### PR DESCRIPTION
## Summary

Cache the SentenceTransformer embedding model at module level instead of re-initializing it on every search request.

Fixes #XX (replace with your issue number)

## Problem

`milvus_search()` in both `server/app.py` and `server-https/app.py` calls `SentenceTransformer(EMBEDDING_MODEL)` on every invocation. Loading `all-mpnet-base-v2` takes ~2-5 seconds and ~400MB. In agentic workflows with 3-5 tool calls per turn, this adds 10-25 seconds of unnecessary latency.

## Changes

- `server/app.py` — move model init to module level
- `server-https/app.py` — move model init to module level

## Performance Impact

| | Before | After |
|---|---|---|
| Model loads per query (5 tool calls) | 5 | 0 |
| Overhead per query | ~15s | ~0s |
| Memory allocation per query | ~2GB | 0 |
| Startup time | unchanged | +3-5s (one-time) |