### PR TITLE
docs: add CHANGELOG.md to track project history and planned features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to the Kubeflow docs-agent are 
+documented here.
+
+## [Unreleased]
+
+### Planned (GSoC 2026)
+- Agentic architecture using LangGraph or Kagent
+- Multi-source querying (docs + GitHub Issues + 
+  Platform Architecture)
+- KServe Scale-to-Zero deployment
+- Terraform/Manifests for OCI deployment
+- Evaluation framework for retrieval accuracy
+
+---
+
+## [0.3.0] — 2026 (Recent)
+
+### Added
+- Kagent POC with Feast as the feature store
+- `kagent-feast-mcp/` directory with MCP integration
+- Updated GSoC 2026 Agentic RAG Architecture Proposal
+  (`gsoc2026_agentic_rag.md`)
+
+### Fixed
+- Replaced hardcoded namespace in manifests, 
+  pipelines, and deployment files
+
+---
+
+## [0.2.0] — 2025
+
+### Added
+- HTTPS API server (`server-https/app.py`) with 
+  FastAPI framework
+- WebSocket API server (`server/app.py`)
+- Kubeflow Pipeline for automated ETL
+  (`pipelines/kubeflow-pipeline.py`)
+- Milvus vector database integration
+- KServe inference service configuration
+- Kubernetes manifests for deployment
+- CONTRIBUTING.md contributor guide
+
+### Architecture
+- Dual API: WebSocket for real-time chat, 
+  HTTPS for RESTful integration
+- RAG pipeline: fetch → chunk → embed → store
+- Tool calling with automatic documentation lookup
+- Citation tracking and deduplication
+
+---
+
+## [0.1.0] — 2025 (Initial Release)
+
+### Added
+- Initial project structure
+- Basic RAG implementation
+- Documentation assets (architecture diagrams)
+- Apache 2.0 License
+
+---
+
+## How to Update This Changelog
+
+When making changes, add an entry under `[Unreleased]`:
+
+### Added
+- New feature description
+
+### Fixed  
+- Bug fix description
+
+### Changed
+- Modified behavior description
+
+### Removed
+- Deprecated feature removed
+
+Follow [Keep a Changelog](https://keepachangelog.com/) 
+format and [Semantic Versioning](https://semver.org/).


### PR DESCRIPTION
## Summary
This PR adds a `CHANGELOG.md` file documenting the 
project history and planned features.

## Motivation
The repo has 19+ commits and active development but 
no changelog. Contributors and users cannot easily 
understand what changed between versions.

## Changes
- Added CHANGELOG.md following Keep a Changelog format
- Documented recent changes based on commit history
- Added Unreleased section showing GSoC 2026 planned work
- Included instructions for future contributors

As a GSoC 2026 applicant for Project 1 (Agentic RAG 
on Kubeflow), I created this to better understand the 
project history and document planned work.