### PR TITLE
test: add test suite and CI workflow (71 tests)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,19 +52,16 @@ jobs:
             tests
 
   test:
-    name: Pytest (${{ matrix.python-version }})
+    name: Pytest
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: requirements-test.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: PR Safety
 
 on:
   push:
@@ -7,7 +7,52 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint and format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install lint tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff
+
+      - name: Run ruff lint
+        run: ruff check .
+
+      - name: Check formatting
+        run: ruff format --check kagent-feast-mcp/mcp-server tests
+
+  compile:
+    name: Python compile check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile Python sources
+        run: |
+          python -m compileall \
+            pipelines \
+            kagent-feast-mcp/mcp-server \
+            server \
+            server-https \
+            scripts \
+            tests
+
   test:
+    name: Pytest (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,5 +74,4 @@ jobs:
           pip install -r requirements-test.txt
 
       - name: Run tests
-        run: |
-          pytest tests/ -v --tb=short
+        run: pytest -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: PR Safety
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat/test-infra]
   pull_request:
-    branches: [main]
+    branches: [main, feat/test-infra]
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: requirements-test.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,9 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+# Claude Code
+.claude/
+
 # Cursor
 #  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data

--- a/kagent-feast-mcp/manifests/kagent/setup.yaml
+++ b/kagent-feast-mcp/manifests/kagent/setup.yaml
@@ -53,6 +53,8 @@ spec:
           kind: RemoteMCPServer
           toolNames:
             - search_kubeflow_docs
+            - search_github_issues
+            - search_kubeflow_code
     systemMessage: |-
       You are the Kubeflow Docs Assistant.
 
@@ -63,20 +65,24 @@ spec:
       Your role
       - Always answer the user's question directly.
       - If the question can be answered from general knowledge (e.g., greetings, small talk, generic programming/Kubernetes basics), respond without using tools.
-      - If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), then use the search_kubeflow_docs tool to find authoritative references, and construct your response using the information provided.
+      - If the question clearly requires Kubeflow-specific knowledge (Pipelines, KServe, Notebooks/Jupyter, Katib, SDK/CLI/APIs, installation, configuration, errors, release details), use the appropriate tool(s) to find authoritative references.
 
-      Tool Use
-      - Use search_kubeflow_docs ONLY when Kubeflow-specific documentation is needed.
-      - Do NOT use the tool for greetings, personal questions, small talk, or generic non-Kubeflow concepts.
-      - When you do call the tool:
-        - Use one clear, focused query.
-        - Summarize the result in your own words.
-        - If no results are relevant, say "not found in the docs" and suggest refining the query.
+      Available Tools
+      - search_kubeflow_docs: Search official Kubeflow documentation. Use for how-to guides, concepts, installation, configuration, and API references.
+      - search_github_issues: Search Kubeflow GitHub issues across repos (kubeflow/kubeflow, kubeflow/pipelines, kubeflow/manifests, kubeflow/katib, kserve/kserve, kubeflow/website). Use for bug reports, troubleshooting, error messages, and community solutions.
+      - search_kubeflow_code: Search Kubeflow code and YAML manifests. Use for Kubernetes resource definitions (Deployments, Services, ConfigMaps), Python source code, and infrastructure configs. Supports filtering by resource_kind.
 
-      Routing
+      Tool Routing
       - Greetings/small talk: respond briefly, no tool.
       - Out-of-scope (sports, unrelated topics): politely say you only help with Kubeflow.
-      - Kubeflow-specific: answer and call the tool if documentation is needed.
+      - Documentation questions (how to, concepts, setup): use search_kubeflow_docs.
+      - Error messages, bugs, troubleshooting: use search_github_issues first, optionally search_kubeflow_docs for context.
+      - Code/manifest questions (YAML, resource definitions, source code): use search_kubeflow_code.
+      - Complex questions: you may call multiple tools to build a comprehensive answer.
+      - When you do call a tool:
+        - Use one clear, focused query per call.
+        - Summarize the result in your own words.
+        - If no results are relevant, say "not found" and suggest refining the query.
 
       Style
       - Be concise (2-5 sentences). Use bullet points or steps when helpful.

--- a/kagent-feast-mcp/mcp-server/requirements.txt
+++ b/kagent-feast-mcp/mcp-server/requirements.txt
@@ -1,4 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch
 fastmcp
 pymilvus
 sentence-transformers
-torch

--- a/kagent-feast-mcp/mcp-server/server.py
+++ b/kagent-feast-mcp/mcp-server/server.py
@@ -1,13 +1,17 @@
+import os
+
 from fastmcp import FastMCP
 from pymilvus import MilvusClient
 from sentence_transformers import SentenceTransformer
 
-MILVUS_URI = "http://milvus.<YOUR_NAMESPACE>.svc.cluster.local:19530"
-MILVUS_USER = "root"
-MILVUS_PASSWORD = "Milvus"
-COLLECTION_NAME = "kubeflow_docs_docs_rag"
-EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
-PORT = 8000
+MILVUS_URI = os.getenv("MILVUS_URI", "http://localhost:19530")
+MILVUS_USER = os.getenv("MILVUS_USER", "root")
+MILVUS_PASSWORD = os.getenv("MILVUS_PASSWORD", "Milvus")
+COLLECTION_NAME = os.getenv("COLLECTION_NAME", "kubeflow_docs_docs_rag")
+ISSUES_COLLECTION_NAME = os.getenv("ISSUES_COLLECTION_NAME", "issues_rag")
+CODE_COLLECTION_NAME = os.getenv("CODE_COLLECTION_NAME", "code_rag")
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-mpnet-base-v2")
+PORT = int(os.getenv("PORT", "8000"))
 
 mcp = FastMCP("Kubeflow Docs MCP Server")
 
@@ -23,6 +27,22 @@ def _init():
         client = MilvusClient(uri=MILVUS_URI, user=MILVUS_USER, password=MILVUS_PASSWORD)
 
 
+def _search_collection(collection_name: str, query: str, top_k: int, output_fields: list[str], filter_expr: str = "") -> list[dict]:
+    """Shared helper: encode query and search a Milvus collection."""
+    _init()
+    embedding = model.encode(query).tolist()
+    search_params = {
+        "collection_name": collection_name,
+        "data": [embedding],
+        "limit": top_k,
+        "output_fields": output_fields,
+    }
+    if filter_expr:
+        search_params["filter"] = filter_expr
+    hits = client.search(**search_params)[0]
+    return hits
+
+
 @mcp.tool()
 def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
     """Search Kubeflow documentation using semantic similarity.
@@ -34,16 +54,10 @@ def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
     Returns:
         Formatted search results with content and citation URLs.
     """
-    _init()
-
-    embedding = model.encode(query).tolist()
-
-    hits = client.search(
-        collection_name=COLLECTION_NAME,
-        data=[embedding],
-        limit=top_k,
-        output_fields=["content_text", "citation_url", "file_path"],
-    )[0]
+    hits = _search_collection(
+        COLLECTION_NAME, query, top_k,
+        ["content_text", "citation_url", "file_path"],
+    )
 
     if not hits:
         return "No results found for your query."
@@ -55,6 +69,121 @@ def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
         entry += f"\n**Source:** {entity.get('citation_url', '')}"
         entry += f"\n**File:** {entity.get('file_path', '')}"
         entry += f"\n\n{entity.get('content_text', '')}\n"
+        results.append(entry)
+
+    return "\n---\n".join(results)
+
+
+@mcp.tool()
+def search_github_issues(query: str, top_k: int = 5, repo: str = "", state: str = "") -> str:
+    """Search Kubeflow GitHub issues for bug reports, troubleshooting,
+    and community solutions. Searches across all repositories including
+    kubeflow/kubeflow, kubeflow/pipelines, kubeflow/manifests,
+    kubeflow/katib, kserve/kserve, and kubeflow/website.
+
+    Args:
+        query: Search query about errors, bugs, or issues.
+        top_k: Number of results to return (default 5).
+        repo: Optional filter by repository (e.g., "kubeflow/kubeflow").
+        state: Optional filter by issue state ("open" or "closed").
+
+    Returns:
+        Formatted search results with content and GitHub issue URLs.
+    """
+    filters = []
+    if repo:
+        filters.append(f'repo_name == "{repo}"')
+    if state:
+        filters.append(f'issue_state == "{state}"')
+    filter_expr = " and ".join(filters)
+
+    hits = _search_collection(
+        ISSUES_COLLECTION_NAME, query, top_k,
+        ["content_text", "citation_url", "repo_name",
+         "issue_number", "issue_state", "issue_labels"],
+        filter_expr=filter_expr,
+    )
+
+    if not hits:
+        return "No issues found for your query."
+
+    results = []
+    for i, hit in enumerate(hits, 1):
+        entity = hit["entity"]
+        entry = f"### Result {i} (score: {hit['distance']:.4f})"
+        entry += f"\n**Source:** {entity.get('citation_url', '')}"
+        entry += f"\n**Repo:** {entity.get('repo_name', '')}"
+
+        issue_num = entity.get("issue_number", "")
+        state = entity.get("issue_state", "")
+        labels = entity.get("issue_labels", "")
+        if issue_num:
+            entry += f"\n**Issue:** #{issue_num}"
+        if state:
+            entry += f" ({state})"
+        if labels:
+            entry += f"\n**Labels:** {labels}"
+
+        entry += f"\n\n{entity.get('content_text', '')}\n"
+        results.append(entry)
+
+    return "\n---\n".join(results)
+
+
+@mcp.tool()
+def search_kubeflow_code(query: str, top_k: int = 5, resource_kind: str = "") -> str:
+    """Search Kubeflow code and YAML manifests using semantic similarity.
+
+    Use this tool when the user asks about Kubernetes manifests, YAML
+    configurations, Deployments, Services, ConfigMaps, Python source code,
+    or infrastructure definitions in the Kubeflow project.
+
+    Args:
+        query: The search query about Kubeflow code or manifests.
+        top_k: Number of results to return (default 5).
+        resource_kind: Optional filter by Kubernetes resource kind
+            (e.g., "Deployment", "Service", "ConfigMap", "StatefulSet",
+            "ServiceAccount", "ClusterRole", "Role", "RoleBinding").
+            When set, only chunks matching this exact kind are returned.
+            For Python code use "function", "class", or "module".
+            Leave empty to search all resource types.
+
+    Returns:
+        Formatted search results with code content, resource metadata,
+        and citation URLs.
+    """
+    filter_expr = f"resource_kind == '{resource_kind}'" if resource_kind else ""
+    hits = _search_collection(
+        CODE_COLLECTION_NAME, query, top_k,
+        ["content_text", "citation_url", "file_path", "resource_kind",
+         "resource_name", "resource_namespace", "file_type"],
+        filter_expr=filter_expr,
+    )
+
+    if not hits:
+        return "No code results found for your query."
+
+    results = []
+    for i, hit in enumerate(hits, 1):
+        entity = hit["entity"]
+        entry = f"### Result {i} (score: {hit['distance']:.4f})"
+        entry += f"\n**Source:** {entity.get('citation_url', '')}"
+        entry += f"\n**File:** {entity.get('file_path', '')}"
+
+        kind = entity.get("resource_kind", "")
+        name = entity.get("resource_name", "")
+        ns = entity.get("resource_namespace", "")
+        ftype = entity.get("file_type", "")
+        if kind or name:
+            entry += f"\n**Resource:** {kind}"
+            if name:
+                entry += f" `{name}`"
+            if ns:
+                entry += f" (namespace: {ns})"
+        if ftype:
+            entry += f"\n**Type:** {ftype}"
+
+        entry += f"\n\n```\n{entity.get('content_text', '')}\n```\n"
         results.append(entry)
 
     return "\n---\n".join(results)

--- a/kagent-feast-mcp/mcp-server/server.py
+++ b/kagent-feast-mcp/mcp-server/server.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from fastmcp import FastMCP
 from pymilvus import MilvusClient
@@ -18,6 +19,8 @@ mcp = FastMCP("Kubeflow Docs MCP Server")
 model: SentenceTransformer = None
 client: MilvusClient = None
 
+_FILTER_VALUE_RE = re.compile(r"^[A-Za-z0-9_/.\-]+$")
+
 
 def _init():
     global model, client
@@ -27,7 +30,9 @@ def _init():
         client = MilvusClient(uri=MILVUS_URI, user=MILVUS_USER, password=MILVUS_PASSWORD)
 
 
-def _search_collection(collection_name: str, query: str, top_k: int, output_fields: list[str], filter_expr: str = "") -> list[dict]:
+def _search_collection(
+    collection_name: str, query: str, top_k: int, output_fields: list[str], filter_expr: str = ""
+) -> list[dict]:
     """Shared helper: encode query and search a Milvus collection."""
     _init()
     embedding = model.encode(query).tolist()
@@ -43,6 +48,13 @@ def _search_collection(collection_name: str, query: str, top_k: int, output_fiel
     return hits
 
 
+def _safe_filter_value(name: str, value: str) -> str:
+    """Validate user-controlled values before interpolating Milvus expressions."""
+    if not _FILTER_VALUE_RE.fullmatch(value):
+        raise ValueError(f"Invalid {name} filter value: {value!r}")
+    return value
+
+
 @mcp.tool()
 def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
     """Search Kubeflow documentation using semantic similarity.
@@ -55,7 +67,9 @@ def search_kubeflow_docs(query: str, top_k: int = 5) -> str:
         Formatted search results with content and citation URLs.
     """
     hits = _search_collection(
-        COLLECTION_NAME, query, top_k,
+        COLLECTION_NAME,
+        query,
+        top_k,
         ["content_text", "citation_url", "file_path"],
     )
 
@@ -92,15 +106,18 @@ def search_github_issues(query: str, top_k: int = 5, repo: str = "", state: str 
     """
     filters = []
     if repo:
+        repo = _safe_filter_value("repo", repo)
         filters.append(f'repo_name == "{repo}"')
     if state:
+        state = _safe_filter_value("state", state)
         filters.append(f'issue_state == "{state}"')
     filter_expr = " and ".join(filters)
 
     hits = _search_collection(
-        ISSUES_COLLECTION_NAME, query, top_k,
-        ["content_text", "citation_url", "repo_name",
-         "issue_number", "issue_state", "issue_labels"],
+        ISSUES_COLLECTION_NAME,
+        query,
+        top_k,
+        ["content_text", "citation_url", "repo_name", "issue_number", "issue_state", "issue_labels"],
         filter_expr=filter_expr,
     )
 
@@ -152,11 +169,22 @@ def search_kubeflow_code(query: str, top_k: int = 5, resource_kind: str = "") ->
         Formatted search results with code content, resource metadata,
         and citation URLs.
     """
+    if resource_kind:
+        resource_kind = _safe_filter_value("resource_kind", resource_kind)
     filter_expr = f"resource_kind == '{resource_kind}'" if resource_kind else ""
     hits = _search_collection(
-        CODE_COLLECTION_NAME, query, top_k,
-        ["content_text", "citation_url", "file_path", "resource_kind",
-         "resource_name", "resource_namespace", "file_type"],
+        CODE_COLLECTION_NAME,
+        query,
+        top_k,
+        [
+            "content_text",
+            "citation_url",
+            "file_path",
+            "resource_kind",
+            "resource_name",
+            "resource_namespace",
+            "file_type",
+        ],
         filter_expr=filter_expr,
     )
 

--- a/pipelines/code-pipeline.py
+++ b/pipelines/code-pipeline.py
@@ -1,0 +1,498 @@
+import kfp
+from kfp import dsl
+from kfp.dsl import *
+from typing import *
+
+
+@dsl.component(
+    base_image="docker.io/python:3.9",
+    packages_to_install=["requests"]
+)
+def download_github_code(
+    repos: str,
+    directory_paths: str,
+    file_extensions: str,
+    github_token: str,
+    code_data: dsl.Output[dsl.Dataset]
+):
+    """Fetch code files from GitHub repositories for RAG indexing.
+
+    Recursively downloads files matching given extensions from specified
+    directories across multiple repositories.
+
+    Args:
+        repos: Comma-separated repos (e.g., "kubeflow/manifests,kubeflow/pipelines").
+        directory_paths: Comma-separated directory paths to crawl per repo
+            (e.g., "apps/pipeline,common/istio").
+        file_extensions: Comma-separated extensions to include
+            (e.g., "yaml,yml,py,json").
+        github_token: GitHub personal access token.
+        code_data: Output dataset path.
+    """
+    import requests
+    import json
+    import base64
+    import time
+
+    headers = {"Authorization": f"token {github_token}"} if github_token else {}
+    extensions = [ext.strip().lstrip(".") for ext in file_extensions.split(",")]
+
+    def api_request(url, params=None):
+        """GitHub API request with rate limit handling and retries."""
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                resp = requests.get(url, params=params, headers=headers)
+
+                if resp.status_code == 403:
+                    remaining = resp.headers.get("X-RateLimit-Remaining", "0")
+                    if remaining == "0":
+                        reset_time = int(resp.headers.get("X-RateLimit-Reset", 0))
+                        wait_time = max(reset_time - int(time.time()), 60)
+                        print(f"Rate limited. Waiting {wait_time}s...")
+                        time.sleep(min(wait_time, 300))
+                        continue
+
+                if resp.status_code == 200:
+                    return resp.json()
+                else:
+                    print(f"API error: HTTP {resp.status_code} for {url}")
+                    return None
+
+            except Exception as e:
+                print(f"Request failed (attempt {attempt+1}): {e}")
+                time.sleep(2 ** attempt)
+
+        return None
+
+    def get_files_recursive(owner, name, path):
+        """Recursively fetch files from a GitHub directory."""
+        files = []
+        url = f"https://api.github.com/repos/{owner}/{name}/contents/{path}"
+        items = api_request(url)
+
+        if not items or not isinstance(items, list):
+            return files
+
+        for item in items:
+            if item["type"] == "file":
+                ext = item["name"].rsplit(".", 1)[-1].lower() if "." in item["name"] else ""
+                # Also include extensionless files like Dockerfile, Makefile
+                include_no_ext = item["name"] in ("Dockerfile", "Makefile", "Kustomization")
+                if ext in extensions or include_no_ext:
+                    try:
+                        file_resp = api_request(item["url"])
+                        if file_resp and "content" in file_resp:
+                            content = base64.b64decode(file_resp["content"]).decode("utf-8")
+                            files.append({
+                                "path": item["path"],
+                                "content": content,
+                                "file_name": item["name"],
+                                "repo": f"{owner}/{name}",
+                            })
+                    except Exception as e:
+                        print(f"Error decoding {item['path']}: {e}")
+            elif item["type"] == "dir":
+                files.extend(get_files_recursive(owner, name, item["path"]))
+
+        return files
+
+    all_files = []
+    dirs = [d.strip() for d in directory_paths.split(",")]
+
+    for repo in repos.split(","):
+        repo = repo.strip()
+        if "/" not in repo:
+            print(f"Skipping invalid repo format: {repo}")
+            continue
+
+        owner, name = repo.split("/", 1)
+        print(f"Fetching code from {owner}/{name}...")
+
+        for dir_path in dirs:
+            print(f"  Scanning {dir_path}/ ...")
+            files = get_files_recursive(owner, name, dir_path)
+            all_files.extend(files)
+            print(f"  Found {len(files)} files in {dir_path}/")
+
+    print(f"Total code files fetched: {len(all_files)}")
+
+    with open(code_data.path, "w", encoding="utf-8") as f:
+        for file_data in all_files:
+            f.write(json.dumps(file_data, ensure_ascii=False) + "\n")
+
+
+@dsl.component(
+    base_image="docker.io/pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime",
+    packages_to_install=["sentence-transformers==3.3.1", "transformers==4.44.2", "langchain-text-splitters", "pyyaml"]
+)
+def chunk_and_embed_code(
+    code_data: dsl.Input[dsl.Dataset],
+    chunk_size: int,
+    chunk_overlap: int,
+    embedded_data: dsl.Output[dsl.Dataset]
+):
+    """Chunk code files using YAML-aware and Python AST-aware parsing, then embed.
+
+    Routes files to the appropriate parser:
+    - .yaml/.yml: Split at --- boundaries, extract K8s metadata
+    - .py: Split at function/class boundaries using ast
+    - .json: Index as single chunk
+    - Others: Text-based fallback
+
+    Oversized chunks are sub-split with RecursiveCharacterTextSplitter.
+    """
+    import json
+    import re
+    import ast as ast_module
+    import yaml
+    import torch
+    from sentence_transformers import SentenceTransformer
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = SentenceTransformer("sentence-transformers/all-mpnet-base-v2", device=device)
+    print(f"Model loaded on {device}")
+
+    # --- Inline chunking logic (KFP components can't import local modules) ---
+
+    def parse_yaml_documents(content, file_path=""):
+        chunks = []
+        file_name = file_path.rsplit("/", 1)[-1] if file_path else ""
+        if file_name in ("kustomization.yaml", "kustomization.yml"):
+            file_type = "kustomize"
+        else:
+            file_type = "yaml"
+
+        raw_docs = re.split(r'^---\s*$', content, flags=re.MULTILINE)
+        for raw_doc in raw_docs:
+            raw_doc = raw_doc.strip()
+            if not raw_doc or len(raw_doc) < 10:
+                continue
+
+            resource_kind = ""
+            resource_name = ""
+            resource_namespace = ""
+            try:
+                parsed = yaml.safe_load(raw_doc)
+                if isinstance(parsed, dict):
+                    resource_kind = str(parsed.get("kind", ""))
+                    metadata = parsed.get("metadata", {})
+                    if isinstance(metadata, dict):
+                        resource_name = str(metadata.get("name", ""))
+                        resource_namespace = str(metadata.get("namespace", ""))
+            except yaml.YAMLError:
+                pass
+
+            chunks.append({
+                "content": raw_doc,
+                "resource_kind": resource_kind,
+                "resource_name": resource_name,
+                "resource_namespace": resource_namespace,
+                "file_type": file_type,
+            })
+        return chunks
+
+    def parse_python_ast(content, file_path=""):
+        chunks = []
+        lines = content.split("\n")
+        try:
+            tree = ast_module.parse(content)
+        except SyntaxError:
+            return [{
+                "content": content,
+                "resource_kind": "",
+                "resource_name": "",
+                "resource_namespace": "",
+                "file_type": "python",
+            }]
+
+        nodes = []
+        for node in ast_module.iter_child_nodes(tree):
+            if isinstance(node, (ast_module.FunctionDef, ast_module.AsyncFunctionDef, ast_module.ClassDef)):
+                nodes.append(node)
+
+        if not nodes:
+            return [{
+                "content": content,
+                "resource_kind": "module",
+                "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+                "resource_namespace": "",
+                "file_type": "python",
+            }]
+
+        first_node_line = nodes[0].lineno
+        if first_node_line > 1:
+            header = "\n".join(lines[:first_node_line - 1]).strip()
+            if header and len(header) >= 10:
+                chunks.append({
+                    "content": header,
+                    "resource_kind": "module_header",
+                    "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+                    "resource_namespace": "",
+                    "file_type": "python",
+                })
+
+        for i, node in enumerate(nodes):
+            start_line = node.lineno - 1
+            if node.decorator_list:
+                start_line = node.decorator_list[0].lineno - 1
+            if i + 1 < len(nodes):
+                next_start = nodes[i + 1].lineno - 1
+                if nodes[i + 1].decorator_list:
+                    next_start = nodes[i + 1].decorator_list[0].lineno - 1
+                end_line = next_start
+            else:
+                end_line = len(lines)
+
+            chunk_content = "\n".join(lines[start_line:end_line]).rstrip()
+            if not chunk_content or len(chunk_content) < 10:
+                continue
+
+            if isinstance(node, ast_module.ClassDef):
+                kind = "class"
+            elif isinstance(node, ast_module.AsyncFunctionDef):
+                kind = "async_function"
+            else:
+                kind = "function"
+
+            chunks.append({
+                "content": chunk_content,
+                "resource_kind": kind,
+                "resource_name": node.name,
+                "resource_namespace": "",
+                "file_type": "python",
+            })
+        return chunks
+
+    def chunk_code_file(content, file_path, c_size, c_overlap):
+        ext = file_path.rsplit(".", 1)[-1].lower() if "." in file_path else ""
+        if ext in ("yaml", "yml"):
+            raw_chunks = parse_yaml_documents(content, file_path)
+        elif ext == "py":
+            raw_chunks = parse_python_ast(content, file_path)
+        elif ext == "json":
+            raw_chunks = [{
+                "content": content,
+                "resource_kind": "",
+                "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+                "resource_namespace": "",
+                "file_type": "json",
+            }]
+        else:
+            raw_chunks = [{
+                "content": content,
+                "resource_kind": "",
+                "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+                "resource_namespace": "",
+                "file_type": ext if ext else "text",
+            }]
+
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=c_size,
+            chunk_overlap=c_overlap,
+            length_function=len,
+            separators=["\n\n", "\n", ". ", " ", ""],
+        )
+        result = []
+        for chunk in raw_chunks:
+            text = chunk["content"]
+            if len(text) <= c_size:
+                result.append(chunk)
+            else:
+                for sub_text in splitter.split_text(text):
+                    result.append({
+                        "content": sub_text,
+                        "resource_kind": chunk["resource_kind"],
+                        "resource_name": chunk["resource_name"],
+                        "resource_namespace": chunk["resource_namespace"],
+                        "file_type": chunk["file_type"],
+                    })
+        return result
+
+    # --- End inline chunking logic ---
+
+    records = []
+
+    with open(code_data.path, "r", encoding="utf-8") as f:
+        for line in f:
+            file_data = json.loads(line)
+            content = file_data["content"]
+            file_path = file_data["path"]
+            repo = file_data.get("repo", "")
+
+            # Light cleaning: normalize whitespace but preserve structure
+            # (YAML/Python are whitespace-sensitive, so no aggressive cleaning)
+            content = content.rstrip()
+            if len(content) < 10:
+                print(f"Skipping tiny file: {file_path} ({len(content)} chars)")
+                continue
+
+            file_unique_id = f"{repo}:{file_path}"
+            # Citation URL: link to GitHub blob
+            citation_url = f"https://github.com/{repo}/blob/main/{file_path}"
+
+            chunks = chunk_code_file(content, file_path, chunk_size, chunk_overlap)
+
+            print(f"File: {file_path} -> {len(chunks)} chunks")
+
+            for chunk_idx, chunk in enumerate(chunks):
+                embedding = model.encode(chunk["content"]).tolist()
+                records.append({
+                    "file_unique_id": file_unique_id,
+                    "repo_name": repo,
+                    "file_path": file_path,
+                    "file_name": file_data["file_name"],
+                    "citation_url": citation_url[:1024],
+                    "chunk_index": chunk_idx,
+                    "content_text": chunk["content"][:2000],
+                    "embedding": embedding,
+                    "resource_kind": chunk["resource_kind"][:128],
+                    "resource_name": chunk["resource_name"][:256],
+                    "resource_namespace": chunk["resource_namespace"][:256],
+                    "file_type": chunk["file_type"][:64],
+                })
+
+    print(f"Created {len(records)} total code chunks")
+
+    with open(embedded_data.path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+@dsl.component(
+    base_image="docker.io/python:3.9",
+    packages_to_install=["pymilvus", "numpy"]
+)
+def store_code_milvus(
+    embedded_data: dsl.Input[dsl.Dataset],
+    milvus_host: str,
+    milvus_port: str,
+    collection_name: str
+):
+    """Store code embeddings in the code_rag Milvus collection.
+
+    Creates the collection with the code_rag schema if it doesn't exist.
+    Uses upsert-style logic: drops and recreates to avoid schema drift.
+    """
+    from pymilvus import connections, utility, FieldSchema, CollectionSchema, DataType, Collection
+    import json
+    from datetime import datetime
+
+    connections.connect("default", host=milvus_host, port=milvus_port)
+
+    # Drop existing collection to ensure schema matches
+    if utility.has_collection(collection_name):
+        utility.drop_collection(collection_name)
+        print(f"Dropped existing collection: {collection_name}")
+
+    # code_rag schema: docs_rag fields + resource_kind, resource_name,
+    # resource_namespace, file_type
+    fields = [
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+        FieldSchema(name="file_unique_id", dtype=DataType.VARCHAR, max_length=512),
+        FieldSchema(name="repo_name", dtype=DataType.VARCHAR, max_length=256),
+        FieldSchema(name="file_path", dtype=DataType.VARCHAR, max_length=512),
+        FieldSchema(name="file_name", dtype=DataType.VARCHAR, max_length=256),
+        FieldSchema(name="citation_url", dtype=DataType.VARCHAR, max_length=1024),
+        FieldSchema(name="chunk_index", dtype=DataType.INT64),
+        FieldSchema(name="content_text", dtype=DataType.VARCHAR, max_length=2000),
+        FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=768),
+        FieldSchema(name="last_updated", dtype=DataType.INT64),
+        # Code-specific fields
+        FieldSchema(name="resource_kind", dtype=DataType.VARCHAR, max_length=128),
+        FieldSchema(name="resource_name", dtype=DataType.VARCHAR, max_length=256),
+        FieldSchema(name="resource_namespace", dtype=DataType.VARCHAR, max_length=256),
+        FieldSchema(name="file_type", dtype=DataType.VARCHAR, max_length=64),
+    ]
+
+    schema = CollectionSchema(fields, "RAG collection for Kubeflow code and manifests")
+    collection = Collection(collection_name, schema)
+    print(f"Created new collection: {collection_name}")
+
+    records = []
+    timestamp = int(datetime.now().timestamp())
+
+    with open(embedded_data.path, "r", encoding="utf-8") as f:
+        for line in f:
+            record = json.loads(line)
+            records.append({
+                "file_unique_id": record["file_unique_id"],
+                "repo_name": record["repo_name"],
+                "file_path": record["file_path"],
+                "file_name": record["file_name"],
+                "citation_url": record["citation_url"],
+                "chunk_index": record["chunk_index"],
+                "content_text": record["content_text"],
+                "vector": record["embedding"],
+                "last_updated": timestamp,
+                "resource_kind": record.get("resource_kind", ""),
+                "resource_name": record.get("resource_name", ""),
+                "resource_namespace": record.get("resource_namespace", ""),
+                "file_type": record.get("file_type", ""),
+            })
+
+    if records:
+        batch_size = 1000
+        for i in range(0, len(records), batch_size):
+            batch = records[i:i + batch_size]
+            collection.insert(batch)
+
+        collection.flush()
+
+        index_params = {
+            "metric_type": "COSINE",
+            "index_type": "IVF_FLAT",
+            "params": {"nlist": min(1024, len(records))},
+        }
+        collection.create_index("vector", index_params)
+        collection.load()
+        print(f"Inserted {len(records)} records. Total: {collection.num_entities}")
+    else:
+        print("No records to insert")
+
+
+@dsl.pipeline(
+    name="code-rag",
+    description="RAG pipeline for ingesting Kubeflow code and YAML manifests"
+)
+def code_rag_pipeline(
+    repos: str = "kubeflow/manifests",
+    directory_paths: str = "apps/pipeline/upstream,apps/katib,common/istio,apps/jupyter",
+    file_extensions: str = "yaml,yml,py,json",
+    github_token: str = "",
+    chunk_size: int = 1000,
+    chunk_overlap: int = 100,
+    milvus_host: str = "milvus-standalone-final.docs-agent.svc.cluster.local",
+    milvus_port: str = "19530",
+    collection_name: str = "code_rag"
+):
+    download_task = download_github_code(
+        repos=repos,
+        directory_paths=directory_paths,
+        file_extensions=file_extensions,
+        github_token=github_token,
+    )
+
+    chunk_task = chunk_and_embed_code(
+        code_data=download_task.outputs["code_data"],
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+
+    store_task = store_code_milvus(
+        embedded_data=chunk_task.outputs["embedded_data"],
+        milvus_host=milvus_host,
+        milvus_port=milvus_port,
+        collection_name=collection_name,
+    )
+
+
+if __name__ == "__main__":
+    import os
+    os.environ["KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT"] = "true"
+
+    kfp.compiler.Compiler().compile(
+        pipeline_func=code_rag_pipeline,
+        package_path="code_rag_pipeline.yaml",
+    )

--- a/pipelines/code_utils.py
+++ b/pipelines/code_utils.py
@@ -1,0 +1,271 @@
+"""
+Utilities for YAML-aware and Python AST-aware code chunking.
+
+Splits Kubernetes YAML manifests at document boundaries (---) and extracts
+resource metadata (apiVersion, kind, name, namespace). For Python files,
+uses the ast module to split at function/class boundaries.
+
+Falls back to RecursiveCharacterTextSplitter when parsing fails.
+"""
+
+import ast
+import re
+import yaml
+
+
+def parse_yaml_documents(content: str, file_path: str = "") -> list[dict]:
+    """Parse a YAML file into per-document chunks with extracted K8s metadata.
+
+    Each YAML document separated by '---' becomes one chunk. Metadata fields
+    (apiVersion, kind, metadata.name, metadata.namespace) are extracted for
+    searchable storage in Milvus.
+
+    For kustomization.yaml files, the entire file is kept as a single chunk
+    since they are typically small.
+
+    Args:
+        content: Raw YAML file content.
+        file_path: Original file path (used for kustomization detection).
+
+    Returns:
+        List of dicts with keys: content, resource_kind, resource_name,
+        resource_namespace, file_type.
+    """
+    chunks = []
+    file_name = file_path.rsplit("/", 1)[-1] if file_path else ""
+
+    # Determine file_type
+    if file_name == "kustomization.yaml" or file_name == "kustomization.yml":
+        file_type = "kustomize"
+    elif file_name.endswith((".yaml", ".yml")):
+        file_type = "yaml"
+    else:
+        file_type = "yaml"
+
+    # Split on YAML document boundaries
+    raw_docs = re.split(r'^---\s*$', content, flags=re.MULTILINE)
+
+    for raw_doc in raw_docs:
+        raw_doc = raw_doc.strip()
+        if not raw_doc or len(raw_doc) < 10:
+            continue
+
+        resource_kind = ""
+        resource_name = ""
+        resource_namespace = ""
+
+        try:
+            parsed = yaml.safe_load(raw_doc)
+            if isinstance(parsed, dict):
+                resource_kind = str(parsed.get("kind", ""))
+                metadata = parsed.get("metadata", {})
+                if isinstance(metadata, dict):
+                    resource_name = str(metadata.get("name", ""))
+                    resource_namespace = str(metadata.get("namespace", ""))
+                # Also capture apiVersion in the content header for context
+        except yaml.YAMLError:
+            # Likely a Helm template or invalid YAML — still index as text
+            pass
+
+        chunks.append({
+            "content": raw_doc,
+            "resource_kind": resource_kind,
+            "resource_name": resource_name,
+            "resource_namespace": resource_namespace,
+            "file_type": file_type,
+        })
+
+    return chunks
+
+
+def parse_python_ast(content: str, file_path: str = "") -> list[dict]:
+    """Parse a Python file into per-function/class chunks using the ast module.
+
+    Each top-level function or class becomes one chunk. Module-level code
+    (imports, constants) is grouped into a single "module_header" chunk.
+
+    Args:
+        content: Raw Python file content.
+        file_path: Original file path for metadata.
+
+    Returns:
+        List of dicts with keys: content, resource_kind, resource_name,
+        resource_namespace, file_type.
+    """
+    chunks = []
+    lines = content.split("\n")
+
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        # Can't parse — return whole file as one chunk
+        return [{
+            "content": content,
+            "resource_kind": "",
+            "resource_name": "",
+            "resource_namespace": "",
+            "file_type": "python",
+        }]
+
+    # Collect top-level function/class nodes with their line ranges
+    nodes = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            nodes.append(node)
+
+    if not nodes:
+        # No functions/classes — return whole file as one chunk
+        return [{
+            "content": content,
+            "resource_kind": "module",
+            "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+            "resource_namespace": "",
+            "file_type": "python",
+        }]
+
+    # Extract module header (everything before first function/class)
+    first_node_line = nodes[0].lineno  # 1-indexed
+    if first_node_line > 1:
+        header = "\n".join(lines[:first_node_line - 1]).strip()
+        if header and len(header) >= 10:
+            chunks.append({
+                "content": header,
+                "resource_kind": "module_header",
+                "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+                "resource_namespace": "",
+                "file_type": "python",
+            })
+
+    # Extract each function/class
+    for i, node in enumerate(nodes):
+        start_line = node.lineno - 1  # Convert to 0-indexed
+
+        # Include decorators if present
+        if node.decorator_list:
+            start_line = node.decorator_list[0].lineno - 1
+
+        # End line: start of next node or end of file
+        if i + 1 < len(nodes):
+            next_start = nodes[i + 1].lineno - 1
+            if nodes[i + 1].decorator_list:
+                next_start = nodes[i + 1].decorator_list[0].lineno - 1
+            end_line = next_start
+        else:
+            end_line = len(lines)
+
+        chunk_content = "\n".join(lines[start_line:end_line]).rstrip()
+        if not chunk_content or len(chunk_content) < 10:
+            continue
+
+        if isinstance(node, ast.ClassDef):
+            kind = "class"
+        elif isinstance(node, ast.AsyncFunctionDef):
+            kind = "async_function"
+        else:
+            kind = "function"
+
+        chunks.append({
+            "content": chunk_content,
+            "resource_kind": kind,
+            "resource_name": node.name,
+            "resource_namespace": "",
+            "file_type": "python",
+        })
+
+    return chunks
+
+
+def parse_json_file(content: str, file_path: str = "") -> list[dict]:
+    """Return a JSON file as a single chunk.
+
+    JSON config files (e.g., package.json, tsconfig.json) are typically small
+    and should be indexed whole.
+
+    Args:
+        content: Raw JSON file content.
+        file_path: Original file path for metadata.
+
+    Returns:
+        Single-element list with the file as one chunk.
+    """
+    return [{
+        "content": content,
+        "resource_kind": "",
+        "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+        "resource_namespace": "",
+        "file_type": "json",
+    }]
+
+
+def chunk_code_file(
+    content: str,
+    file_path: str,
+    chunk_size: int = 1000,
+    chunk_overlap: int = 100,
+) -> list[dict]:
+    """Route a code file to the appropriate parser based on extension.
+
+    Supports .yaml/.yml (YAML-aware), .py (AST-aware), .json, and
+    generic text fallback for other extensions.
+
+    If the parser produces chunks larger than chunk_size, they are
+    sub-split using RecursiveCharacterTextSplitter.
+
+    Args:
+        content: Raw file content.
+        file_path: File path (used for extension detection and metadata).
+        chunk_size: Maximum chunk size in characters.
+        chunk_overlap: Overlap between sub-split chunks.
+
+    Returns:
+        List of dicts with keys: content, resource_kind, resource_name,
+        resource_namespace, file_type.
+    """
+    try:
+        from langchain.text_splitter import RecursiveCharacterTextSplitter
+    except ImportError:
+        from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+    ext = file_path.rsplit(".", 1)[-1].lower() if "." in file_path else ""
+
+    if ext in ("yaml", "yml"):
+        raw_chunks = parse_yaml_documents(content, file_path)
+    elif ext == "py":
+        raw_chunks = parse_python_ast(content, file_path)
+    elif ext == "json":
+        raw_chunks = parse_json_file(content, file_path)
+    else:
+        # Generic text fallback (Dockerfile, Makefile, .sh, .go, etc.)
+        raw_chunks = [{
+            "content": content,
+            "resource_kind": "",
+            "resource_name": file_path.rsplit("/", 1)[-1] if file_path else "",
+            "resource_namespace": "",
+            "file_type": ext if ext else "text",
+        }]
+
+    # Sub-split oversized chunks
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    result = []
+    for chunk in raw_chunks:
+        text = chunk["content"]
+        if len(text) <= chunk_size:
+            result.append(chunk)
+        else:
+            sub_texts = splitter.split_text(text)
+            for sub_text in sub_texts:
+                result.append({
+                    "content": sub_text,
+                    "resource_kind": chunk["resource_kind"],
+                    "resource_name": chunk["resource_name"],
+                    "resource_namespace": chunk["resource_namespace"],
+                    "file_type": chunk["file_type"],
+                })
+
+    return result

--- a/pipelines/issues-pipeline.py
+++ b/pipelines/issues-pipeline.py
@@ -1,0 +1,415 @@
+"""KFP pipeline for ingesting GitHub issues into Milvus for RAG.
+
+Wires the existing download_github_issues component into a complete pipeline
+with issues-aware chunking and a dedicated issues_rag Milvus collection.
+
+Components are self-contained per KFP convention. The download_github_issues
+component is copied from kubeflow-pipeline.py (lines 67-213) since KFP
+@dsl.component functions must be self-contained with all imports inside.
+"""
+
+import kfp
+from kfp import dsl
+from kfp.dsl import *
+from typing import *
+
+
+@dsl.component(
+    base_image="python:3.9",
+    packages_to_install=["requests"]
+)
+def download_github_issues(
+    repos: str,
+    labels: str,
+    state: str,
+    max_issues_per_repo: int,
+    github_token: str,
+    issues_data: dsl.Output[dsl.Dataset]
+):
+    """Fetch GitHub issues and comments from multiple repos for RAG indexing.
+
+    Args:
+        repos: Comma-separated list of repos (e.g., "kubeflow/kubeflow,kubeflow/pipelines")
+        labels: Comma-separated labels to filter (e.g., "kind/bug,kind/question")
+        state: Issue state - "open", "closed", or "all"
+        max_issues_per_repo: Maximum issues to fetch per repository
+        github_token: GitHub personal access token for API authentication
+        issues_data: Output dataset path
+    """
+    import requests
+    import json
+    import time
+
+    headers = {"Authorization": f"token {github_token}"} if github_token else {}
+    all_issues = []
+
+    def api_request(url, params=None):
+        """Make GitHub API request with rate limit handling."""
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                resp = requests.get(url, params=params, headers=headers)
+
+                # Handle rate limiting
+                if resp.status_code == 403:
+                    remaining = resp.headers.get("X-RateLimit-Remaining", "0")
+                    if remaining == "0":
+                        reset_time = int(resp.headers.get("X-RateLimit-Reset", 0))
+                        wait_time = max(reset_time - int(time.time()), 60)
+                        print(f"Rate limited. Waiting {wait_time}s...")
+                        time.sleep(min(wait_time, 300))  # Max 5 min wait
+                        continue
+
+                if resp.status_code == 200:
+                    return resp.json()
+                else:
+                    print(f"API error: HTTP {resp.status_code}")
+                    return None
+
+            except Exception as e:
+                print(f"Request failed (attempt {attempt+1}): {e}")
+                time.sleep(2 ** attempt)  # Exponential backoff
+
+        return None
+
+    def fetch_comments(owner, name, issue_number):
+        """Fetch all comments for a single issue."""
+        comments_url = f"https://api.github.com/repos/{owner}/{name}/issues/{issue_number}/comments"
+        comments_text = ""
+        page = 1
+
+        while True:
+            comments = api_request(comments_url, {"per_page": 100, "page": page})
+            if not comments:
+                break
+
+            for comment in comments:
+                author = comment.get("user", {}).get("login", "unknown")
+                created = comment.get("created_at", "")[:10]
+                body = comment.get("body", "") or ""
+                comments_text += f"\n\n---\n**Comment by @{author}** ({created}):\n{body}"
+
+            if len(comments) < 100:
+                break
+            page += 1
+
+        return comments_text
+
+    for repo in repos.split(","):
+        repo = repo.strip()
+        if "/" not in repo:
+            print(f"Skipping invalid repo format: {repo}")
+            continue
+
+        owner, name = repo.split("/", 1)
+        print(f"Fetching issues from {owner}/{name}...")
+
+        page = 1
+        repo_issues = []
+
+        while len(repo_issues) < max_issues_per_repo:
+            url = f"https://api.github.com/repos/{owner}/{name}/issues"
+            params = {
+                "state": state,
+                "labels": labels,
+                "per_page": 100,
+                "page": page
+            }
+
+            issues = api_request(url, params)
+            if not issues:
+                break
+
+            for issue in issues:
+                if "pull_request" in issue:
+                    continue
+
+                labels_str = ", ".join([l["name"] for l in issue.get("labels", [])])
+                issue_url = issue.get("html_url", "")
+                created_at = issue.get("created_at", "")[:10]
+                updated_at = issue.get("updated_at", "")[:10]
+
+                # Build issue content with full metadata
+                content = f"# {issue['title']}\n\n"
+                content += f"**Repository:** {repo}\n"
+                content += f"**Issue:** #{issue['number']}\n"
+                content += f"**URL:** {issue_url}\n"
+                content += f"**Labels:** {labels_str}\n"
+                content += f"**State:** {issue['state']}\n"
+                content += f"**Created:** {created_at}\n"
+                content += f"**Updated:** {updated_at}\n\n"
+                content += issue.get("body", "") or ""
+
+                # Fetch and append comments
+                if issue.get("comments", 0) > 0:
+                    comments = fetch_comments(owner, name, issue["number"])
+                    content += comments
+
+                repo_issues.append({
+                    "path": f"issues/{name}/{issue['number']}",
+                    "content": content,
+                    "file_name": f"issue-{name}-{issue['number']}.md",
+                    "url": issue_url
+                })
+
+                if len(repo_issues) >= max_issues_per_repo:
+                    break
+
+            page += 1
+
+        all_issues.extend(repo_issues)
+        print(f"  Fetched {len(repo_issues)} issues from {repo}")
+
+    print(f"Total issues fetched: {len(all_issues)}")
+
+    with open(issues_data.path, 'w', encoding='utf-8') as f:
+        for issue_data in all_issues:
+            f.write(json.dumps(issue_data, ensure_ascii=False) + '\n')
+
+
+@dsl.component(
+    base_image="pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime",
+    packages_to_install=["sentence-transformers", "langchain"]
+)
+def chunk_and_embed_issues(
+    issues_data: dsl.Input[dsl.Dataset],
+    chunk_size: int,
+    chunk_overlap: int,
+    embedded_data: dsl.Output[dsl.Dataset]
+):
+    """Chunk GitHub issues at comment boundaries and generate embeddings.
+
+    Chunking strategy:
+    - Parse metadata (repo, issue number, state, labels, URL) from content
+    - Prepend a metadata prefix to every chunk for self-contained retrieval
+    - Split at comment boundaries (--- separators) first
+    - Subdivide oversized segments with RecursiveCharacterTextSplitter
+    - Short issues (body + comments < chunk_size) become a single chunk
+    """
+    import json
+    import re
+    import torch
+    from sentence_transformers import SentenceTransformer
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = SentenceTransformer('sentence-transformers/all-mpnet-base-v2', device=device)
+    print(f"Model loaded on {device}")
+
+    def parse_metadata(content):
+        """Extract structured metadata from issue content."""
+        title_match = re.search(r'^#\s+(.+)', content, re.MULTILINE)
+        repo_match = re.search(r'\*\*Repository:\*\*\s*(.+)', content)
+        number_match = re.search(r'\*\*Issue:\*\*\s*#(\d+)', content)
+        url_match = re.search(r'\*\*URL:\*\*\s*(.+)', content)
+        labels_match = re.search(r'\*\*Labels:\*\*[ \t]*(.*)', content)
+        state_match = re.search(r'\*\*State:\*\*\s*(\w+)', content)
+        return {
+            "title": title_match.group(1).strip() if title_match else "",
+            "repo_name": repo_match.group(1).strip() if repo_match else "",
+            "issue_number": int(number_match.group(1)) if number_match else 0,
+            "issue_state": state_match.group(1).strip() if state_match else "",
+            "issue_labels": labels_match.group(1).strip() if labels_match else "",
+            "citation_url": url_match.group(1).strip() if url_match else "",
+        }
+
+    def build_prefix(meta):
+        """Build metadata prefix for each chunk."""
+        parts = [f"[Issue #{meta['issue_number']}] {meta['title']}"]
+        if meta["repo_name"]:
+            parts.append(f"Repo: {meta['repo_name']}")
+        if meta["issue_state"]:
+            parts.append(f"State: {meta['issue_state']}")
+        if meta["issue_labels"]:
+            parts.append(f"Labels: {meta['issue_labels']}")
+        return " | ".join(parts) + "\n\n"
+
+    records = []
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    with open(issues_data.path, 'r', encoding='utf-8') as f:
+        for line in f:
+            issue = json.loads(line)
+            content = issue["content"]
+            metadata = parse_metadata(content)
+            prefix = build_prefix(metadata)
+            effective_size = chunk_size - len(prefix)
+            if effective_size < 100:
+                effective_size = 100
+
+            # Split at comment boundaries or keep as single chunk
+            if len(content) <= effective_size:
+                chunks = [prefix + content]
+            else:
+                segments = re.split(r'\n\n---\n', content)
+                chunks = []
+                for segment in segments:
+                    segment = segment.strip()
+                    if not segment:
+                        continue
+                    if len(segment) <= effective_size:
+                        chunks.append(prefix + segment)
+                    else:
+                        for sub in splitter.split_text(segment):
+                            chunks.append(prefix + sub)
+                if not chunks:
+                    chunks = [prefix + content[:effective_size]]
+
+            # Embed and create records
+            for chunk_idx, chunk_text in enumerate(chunks):
+                embedding = model.encode(chunk_text).tolist()
+                records.append({
+                    "file_unique_id": f"{metadata['repo_name']}:issues/{metadata['issue_number']}",
+                    "repo_name": metadata["repo_name"],
+                    "issue_number": metadata["issue_number"],
+                    "issue_state": metadata["issue_state"],
+                    "issue_labels": metadata["issue_labels"],
+                    "citation_url": metadata["citation_url"],
+                    "chunk_index": chunk_idx,
+                    "content_text": chunk_text[:2000],
+                    "embedding": embedding,
+                    "source_type": "issue",
+                })
+
+            print(f"Issue #{metadata['issue_number']}: {len(chunks)} chunks")
+
+    print(f"Total chunks: {len(records)}")
+
+    with open(embedded_data.path, 'w', encoding='utf-8') as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+
+@dsl.component(
+    base_image="python:3.9",
+    packages_to_install=["pymilvus", "numpy"]
+)
+def store_issues_milvus(
+    embedded_data: dsl.Input[dsl.Dataset],
+    milvus_host: str,
+    milvus_port: str,
+    collection_name: str
+):
+    """Store issue embeddings in a dedicated Milvus collection.
+
+    Creates the issues_rag collection with issue-specific schema fields
+    (issue_number, issue_state, issue_labels, source_type).
+    """
+    from pymilvus import connections, utility, FieldSchema, CollectionSchema, DataType, Collection
+    import json
+    from datetime import datetime
+
+    connections.connect("default", host=milvus_host, port=milvus_port)
+
+    if utility.has_collection(collection_name):
+        utility.drop_collection(collection_name)
+        print(f"Dropped existing collection: {collection_name}")
+
+    fields = [
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+        FieldSchema(name="file_unique_id", dtype=DataType.VARCHAR, max_length=512),
+        FieldSchema(name="repo_name", dtype=DataType.VARCHAR, max_length=256),
+        FieldSchema(name="issue_number", dtype=DataType.INT64),
+        FieldSchema(name="issue_state", dtype=DataType.VARCHAR, max_length=32),
+        FieldSchema(name="issue_labels", dtype=DataType.VARCHAR, max_length=1024),
+        FieldSchema(name="citation_url", dtype=DataType.VARCHAR, max_length=1024),
+        FieldSchema(name="chunk_index", dtype=DataType.INT64),
+        FieldSchema(name="content_text", dtype=DataType.VARCHAR, max_length=2000),
+        FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=768),
+        FieldSchema(name="last_updated", dtype=DataType.INT64),
+        FieldSchema(name="source_type", dtype=DataType.VARCHAR, max_length=64),
+    ]
+
+    schema = CollectionSchema(fields, "RAG collection for GitHub issues")
+    collection = Collection(collection_name, schema)
+    print(f"Created collection: {collection_name}")
+
+    records = []
+    timestamp = int(datetime.now().timestamp())
+
+    with open(embedded_data.path, 'r', encoding='utf-8') as f:
+        for line in f:
+            record = json.loads(line)
+            records.append({
+                "file_unique_id": record["file_unique_id"],
+                "repo_name": record["repo_name"],
+                "issue_number": record["issue_number"],
+                "issue_state": record["issue_state"],
+                "issue_labels": record["issue_labels"],
+                "citation_url": record["citation_url"],
+                "chunk_index": record["chunk_index"],
+                "content_text": record["content_text"],
+                "vector": record["embedding"],
+                "last_updated": timestamp,
+                "source_type": record["source_type"],
+            })
+
+    if records:
+        batch_size = 1000
+        for i in range(0, len(records), batch_size):
+            batch = records[i:i + batch_size]
+            collection.insert(batch)
+
+        collection.flush()
+
+        index_params = {
+            "metric_type": "COSINE",
+            "index_type": "IVF_FLAT",
+            "params": {"nlist": min(1024, len(records))}
+        }
+        collection.create_index("vector", index_params)
+        collection.load()
+        print(f"Inserted {len(records)} records. Total: {collection.num_entities}")
+
+
+@dsl.pipeline(
+    name="github-issues-rag",
+    description="RAG pipeline for GitHub issues ingestion"
+)
+def github_issues_rag_pipeline(
+    repos: str = "kubeflow/kubeflow,kubeflow/pipelines,kubeflow/manifests",
+    labels: str = "",
+    state: str = "all",
+    max_issues_per_repo: int = 200,
+    github_token: str = "",
+    chunk_size: int = 1500,
+    chunk_overlap: int = 150,
+    milvus_host: str = "my-release-milvus.docs-agent.svc.cluster.local",
+    milvus_port: str = "19530",
+    collection_name: str = "issues_rag"
+):
+    download_task = download_github_issues(
+        repos=repos,
+        labels=labels,
+        state=state,
+        max_issues_per_repo=max_issues_per_repo,
+        github_token=github_token,
+    )
+
+    chunk_task = chunk_and_embed_issues(
+        issues_data=download_task.outputs["issues_data"],
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+
+    store_issues_milvus(
+        embedded_data=chunk_task.outputs["embedded_data"],
+        milvus_host=milvus_host,
+        milvus_port=milvus_port,
+        collection_name=collection_name,
+    )
+
+
+if __name__ == "__main__":
+    import os
+    os.environ['KFP_DISABLE_EXECUTION_CACHING_BY_DEFAULT'] = 'true'
+    kfp.compiler.Compiler().compile(
+        pipeline_func=github_issues_rag_pipeline,
+        package_path="github_issues_rag_pipeline.yaml"
+    )
+    print("Compiled: github_issues_rag_pipeline.yaml")

--- a/pipelines/issues_utils.py
+++ b/pipelines/issues_utils.py
@@ -1,0 +1,113 @@
+"""Utility functions for GitHub issues pipeline chunking and metadata extraction."""
+
+import re
+
+
+def parse_issue_metadata(content: str) -> dict:
+    """Extract structured metadata from download_github_issues output format.
+
+    The content follows the format produced by the download_github_issues
+    KFP component: title line, metadata lines, body, and comments.
+
+    Args:
+        content: Raw issue content string from download_github_issues.
+
+    Returns:
+        Dict with keys: title, repo_name, issue_number, issue_state,
+        issue_labels, citation_url. Missing fields default to empty string
+        (or 0 for issue_number).
+    """
+    title_match = re.search(r'^#\s+(.+)', content, re.MULTILINE)
+    repo_match = re.search(r'\*\*Repository:\*\*\s*(.+)', content)
+    number_match = re.search(r'\*\*Issue:\*\*\s*#(\d+)', content)
+    url_match = re.search(r'\*\*URL:\*\*\s*(.+)', content)
+    labels_match = re.search(r'\*\*Labels:\*\*[ \t]*(.*)', content)
+    state_match = re.search(r'\*\*State:\*\*\s*(\w+)', content)
+
+    return {
+        "title": title_match.group(1).strip() if title_match else "",
+        "repo_name": repo_match.group(1).strip() if repo_match else "",
+        "issue_number": int(number_match.group(1)) if number_match else 0,
+        "issue_state": state_match.group(1).strip() if state_match else "",
+        "issue_labels": labels_match.group(1).strip() if labels_match else "",
+        "citation_url": url_match.group(1).strip() if url_match else "",
+    }
+
+
+def build_metadata_prefix(metadata: dict) -> str:
+    """Build a self-contained prefix string for each chunk.
+
+    Args:
+        metadata: Dict from parse_issue_metadata.
+
+    Returns:
+        Prefix string like "[Issue #42] Title | Repo: x | State: open | Labels: y"
+    """
+    parts = [f"[Issue #{metadata['issue_number']}] {metadata['title']}"]
+    if metadata["repo_name"]:
+        parts.append(f"Repo: {metadata['repo_name']}")
+    if metadata["issue_state"]:
+        parts.append(f"State: {metadata['issue_state']}")
+    if metadata["issue_labels"]:
+        parts.append(f"Labels: {metadata['issue_labels']}")
+    return " | ".join(parts) + "\n\n"
+
+
+def split_issue_into_chunks(
+    content: str,
+    metadata_prefix: str,
+    chunk_size: int = 1500,
+    chunk_overlap: int = 150,
+) -> list[str]:
+    """Split issue content into chunks at comment boundaries.
+
+    Strategy:
+    - Split at '\\n\\n---\\n' boundaries (comment separators from download_github_issues)
+    - If entire content fits in one chunk, return single chunk
+    - If a segment exceeds chunk_size, subdivide with RecursiveCharacterTextSplitter
+    - Prepend metadata_prefix to every chunk
+
+    Args:
+        content: Full issue content string.
+        metadata_prefix: Prefix to prepend to each chunk.
+        chunk_size: Maximum chunk size in characters.
+        chunk_overlap: Overlap between subdivided chunks.
+
+    Returns:
+        List of chunk strings, each prefixed with metadata.
+    """
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+    # Available space for content after prefix
+    effective_size = chunk_size - len(metadata_prefix)
+    if effective_size < 100:
+        effective_size = 100
+
+    # If entire content fits, return single chunk
+    if len(content) <= effective_size:
+        return [metadata_prefix + content]
+
+    # Split at comment boundaries
+    segments = re.split(r'\n\n---\n', content)
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=effective_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    chunks = []
+    for segment in segments:
+        segment = segment.strip()
+        if not segment:
+            continue
+        if len(segment) <= effective_size:
+            chunks.append(metadata_prefix + segment)
+        else:
+            # Subdivide oversized segment
+            sub_chunks = splitter.split_text(segment)
+            for sub in sub_chunks:
+                chunks.append(metadata_prefix + sub)
+
+    return chunks if chunks else [metadata_prefix + content[:effective_size]]

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -1,0 +1,47 @@
+"""Shared utility functions for pipeline components."""
+
+import re
+
+
+def clean_content(content: str) -> str:
+    """Clean raw document content for better embeddings.
+
+    Removes Hugo frontmatter, template syntax, HTML tags, navigation
+    artifacts, URLs, and normalizes whitespace.
+
+    Args:
+        content: Raw document content (markdown/HTML).
+
+    Returns:
+        Cleaned text suitable for embedding.
+    """
+    # Remove Hugo frontmatter (both --- and +++ styles)
+    # \A anchors to absolute start of string; backreference ensures matching delimiters
+    content = re.sub(
+        r'\A\s*(?P<delim>-{3,}|\+{3,}).*?(?P=delim)\s*', '', content,
+        flags=re.DOTALL
+    )
+
+    # Remove Hugo template syntax
+    content = re.sub(r'\{\{.*?\}\}', '', content, flags=re.DOTALL)
+
+    # Remove HTML comments and tags
+    content = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
+    content = re.sub(r'<[^>]+>', ' ', content)
+
+    # Remove navigation/menu artifacts
+    content = re.sub(
+        r'\b(Get Started|Contribute|GenAI|Home|Menu|Navigation)\b', '',
+        content, flags=re.IGNORECASE
+    )
+
+    # Clean up URLs and links
+    content = re.sub(r'https?://[^\s]+', '', content)
+    content = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', content)
+
+    # Remove excessive whitespace and normalize
+    content = re.sub(r'\s+', ' ', content)
+    content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)
+    content = content.strip()
+
+    return content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
-per-file-ignores = { 
-  "kagent-feast-mcp/pipelines/*.py" = ["F403", "F405"],
-  "pipelines/*.py" = ["F403", "F405", "F841", "E741"],
-  "scripts/index_real_issues.py" = ["F401", "E741"],
-  "server/app.py" = ["F401"],
-  "tests/test_code_utils.py" = ["E402"],
-  "tests/test_issues_pipeline.py" = ["E402"],
-  "tests/test_pipeline_utils.py" = ["E402"],
-}
+
+[tool.ruff.lint.per-file-ignores]
+"kagent-feast-mcp/pipelines/*.py" = ["F403", "F405"]
+"pipelines/*.py" = ["F403", "F405", "F841", "E741"]
+"scripts/index_real_issues.py" = ["F401", "E741"]
+"server/app.py" = ["F401"]
+"tests/test_code_utils.py" = ["E402"]
+"tests/test_issues_pipeline.py" = ["E402"]
+"tests/test_pipeline_utils.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ruff]
+target-version = "py39"
+line-length = 120
+
+[tool.ruff.lint]
+per-file-ignores = { 
+  "kagent-feast-mcp/pipelines/*.py" = ["F403", "F405"],
+  "pipelines/*.py" = ["F403", "F405", "F841", "E741"],
+  "scripts/index_real_issues.py" = ["F401", "E741"],
+  "server/app.py" = ["F401"],
+  "tests/test_code_utils.py" = ["E402"],
+  "tests/test_issues_pipeline.py" = ["E402"],
+  "tests/test_pipeline_utils.py" = ["E402"],
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+markers =
+    unit: deterministic unit tests that do not use network, Milvus, KServe, or model downloads
+    integration: integration tests that may need external services or heavier dependencies
+    legacy: tests for archived or transitional surfaces outside the active Kagent plus MCP runtime
+    slow: tests that are intentionally slower than the default PR suite
+addopts = -m "not integration and not slow and not legacy"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-asyncio>=0.21
 numpy
 fastmcp
 langchain-text-splitters
+pyyaml

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+pytest>=7.0
+pytest-asyncio>=0.21
+numpy
+fastmcp
+langchain-text-splitters

--- a/scripts/index_real_issues.py
+++ b/scripts/index_real_issues.py
@@ -1,0 +1,319 @@
+"""Fetch real GitHub issues, chunk, embed, and index into Milvus.
+
+This script implements the issues ingestion pipeline end-to-end:
+  1. Fetch issues from kubeflow repos via GitHub API
+  2. Chunk using comment-boundary-aware splitting (issues_utils)
+  3. Embed with sentence-transformers/all-mpnet-base-v2
+  4. Store into issues_rag Milvus collection
+
+Usage:
+    # Port-forward first: kubectl port-forward svc/my-release-milvus -n docs-agent 19530:19530
+    python scripts/index_real_issues.py [--max-issues 50] [--repos kubeflow/kubeflow,kubeflow/pipelines]
+
+Set GITHUB_TOKEN env var for higher rate limits.
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+
+import requests
+from pymilvus import (
+    Collection,
+    CollectionSchema,
+    DataType,
+    FieldSchema,
+    connections,
+    utility,
+)
+from sentence_transformers import SentenceTransformer
+
+# Add pipelines to path for issues_utils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "pipelines"))
+from issues_utils import build_metadata_prefix, parse_issue_metadata, split_issue_into_chunks
+
+MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")
+MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
+COLLECTION_NAME = "issues_rag"
+EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
+
+DEFAULT_REPOS = [
+    "kubeflow/kubeflow",
+    "kubeflow/pipelines",
+    "kubeflow/manifests",
+    "kubeflow/katib",
+]
+
+GITHUB_API = "https://api.github.com"
+
+
+def fetch_issues(repo: str, max_issues: int, token: str | None) -> list[dict]:
+    """Fetch issues from a GitHub repo (excludes pull requests)."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    issues = []
+    page = 1
+    per_page = min(max_issues, 100)
+
+    while len(issues) < max_issues:
+        url = f"{GITHUB_API}/repos/{repo}/issues"
+        params = {
+            "state": "all",
+            "per_page": per_page,
+            "page": page,
+            "sort": "updated",
+            "direction": "desc",
+        }
+        resp = requests.get(url, headers=headers, params=params, timeout=30)
+
+        if resp.status_code == 403:
+            reset = int(resp.headers.get("X-RateLimit-Reset", 0))
+            wait = max(reset - int(time.time()), 10)
+            print(f"  Rate limited, waiting {wait}s...")
+            time.sleep(wait)
+            continue
+
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+
+        for item in batch:
+            if "pull_request" in item:
+                continue  # Skip PRs
+            if len(issues) >= max_issues:
+                break
+            issues.append(item)
+
+        page += 1
+
+    return issues
+
+
+def format_issue_content(issue: dict, repo: str, comments: list[dict]) -> str:
+    """Format a GitHub issue into the download_github_issues output format."""
+    labels = ", ".join(l["name"] for l in issue.get("labels", []))
+    state = issue["state"]
+
+    lines = [
+        f"# {issue['title']}",
+        f"**Repository:** {repo}",
+        f"**Issue:** #{issue['number']}",
+        f"**State:** {state}",
+        f"**Labels:** {labels}",
+        f"**URL:** {issue['html_url']}",
+        "",
+        issue.get("body") or "(no description)",
+    ]
+
+    for c in comments:
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+        lines.append(f"**Comment by {c['user']['login']}** ({c['created_at'][:10]}):")
+        lines.append(c.get("body") or "")
+
+    return "\n".join(lines)
+
+
+def fetch_comments(repo: str, issue_number: int, token: str | None) -> list[dict]:
+    """Fetch comments for a specific issue."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}/comments"
+    resp = requests.get(url, headers=headers, params={"per_page": 30}, timeout=30)
+
+    if resp.status_code == 403:
+        return []  # Skip on rate limit
+
+    resp.raise_for_status()
+    return resp.json()
+
+
+COLLECTION_FIELDS = [
+    FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+    FieldSchema(name="file_unique_id", dtype=DataType.VARCHAR, max_length=512),
+    FieldSchema(name="repo_name", dtype=DataType.VARCHAR, max_length=256),
+    FieldSchema(name="issue_number", dtype=DataType.INT64),
+    FieldSchema(name="issue_state", dtype=DataType.VARCHAR, max_length=32),
+    FieldSchema(name="issue_labels", dtype=DataType.VARCHAR, max_length=1024),
+    FieldSchema(name="citation_url", dtype=DataType.VARCHAR, max_length=1024),
+    FieldSchema(name="chunk_index", dtype=DataType.INT64),
+    FieldSchema(name="content_text", dtype=DataType.VARCHAR, max_length=2000),
+    FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=768),
+    FieldSchema(name="last_updated", dtype=DataType.INT64),
+    FieldSchema(name="source_type", dtype=DataType.VARCHAR, max_length=64),
+]
+
+
+def ensure_collection(fresh: bool = False) -> Collection:
+    """Create or get the issues_rag collection.
+
+    Args:
+        fresh: If True, drop and recreate. If False (default), reuse existing.
+    """
+    if utility.has_collection(COLLECTION_NAME):
+        if fresh:
+            utility.drop_collection(COLLECTION_NAME)
+            print(f"Dropped existing {COLLECTION_NAME}")
+        else:
+            print(f"Reusing existing {COLLECTION_NAME} (incremental mode)")
+            col = Collection(COLLECTION_NAME)
+            # Ensure index exists before loading
+            if not col.has_index():
+                print("  Creating missing index...")
+                col.create_index("vector", {
+                    "metric_type": "COSINE",
+                    "index_type": "IVF_FLAT",
+                    "params": {"nlist": min(1024, max(1, col.num_entities))},
+                })
+            col.load()
+            return col
+
+    schema = CollectionSchema(COLLECTION_FIELDS, "RAG collection for GitHub issues")
+    collection = Collection(COLLECTION_NAME, schema)
+    print(f"Created collection: {COLLECTION_NAME}")
+    return collection
+
+
+def get_indexed_issue_ids(collection: Collection, repo: str) -> set[int]:
+    """Return set of issue_numbers already indexed for a given repo."""
+    try:
+        results = collection.query(
+            expr=f'repo_name == "{repo}"',
+            output_fields=["issue_number"],
+            limit=16384,
+        )
+        return {r["issue_number"] for r in results}
+    except Exception:
+        return set()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Index real GitHub issues into Milvus")
+    parser.add_argument("--max-issues", type=int, default=25, help="Max issues per repo")
+    parser.add_argument("--repos", type=str, default=",".join(DEFAULT_REPOS))
+    parser.add_argument("--fresh", action="store_true",
+                        help="Drop and recreate collection (default: incremental)")
+    args = parser.parse_args()
+
+    repos = [r.strip() for r in args.repos.split(",")]
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("WARNING: No GITHUB_TOKEN set. Rate limits will be very low (60 req/hr).")
+
+    # Connect to Milvus
+    print("Connecting to Milvus...")
+    connections.connect("default", host=MILVUS_HOST, port=MILVUS_PORT)
+
+    # Load embedding model
+    print("Loading embedding model...")
+    model = SentenceTransformer(EMBEDDING_MODEL)
+
+    # Create or reuse collection
+    collection = ensure_collection(fresh=args.fresh)
+
+    timestamp = int(time.time())
+    total_chunks = 0
+
+    for repo in repos:
+        print(f"\n{'='*60}")
+        print(f"Fetching issues from {repo}...")
+
+        # In incremental mode, skip already-indexed issues
+        existing_ids = set()
+        if not args.fresh:
+            existing_ids = get_indexed_issue_ids(collection, repo)
+            if existing_ids:
+                print(f"  Already indexed: {len(existing_ids)} issues")
+
+        issues = fetch_issues(repo, args.max_issues, token)
+        # Filter out already-indexed issues
+        issues = [i for i in issues if i["number"] not in existing_ids]
+        print(f"  Got {len(issues)} new issues to index")
+
+        records = []
+        for issue in issues:
+            # Fetch comments
+            comments = fetch_comments(repo, issue["number"], token)
+
+            # Format into pipeline output format
+            content = format_issue_content(issue, repo, comments)
+
+            # Parse metadata and chunk using pipeline utilities
+            metadata = parse_issue_metadata(content)
+            prefix = build_metadata_prefix(metadata)
+            chunks = split_issue_into_chunks(content, prefix, chunk_size=1500, chunk_overlap=150)
+
+            labels = ", ".join(l["name"] for l in issue.get("labels", []))
+
+            for idx, chunk in enumerate(chunks):
+                # Truncate to fit VARCHAR(2000)
+                chunk_text = chunk[:2000]
+                embedding = model.encode(chunk_text).tolist()
+
+                records.append({
+                    "file_unique_id": f"{repo}:issues/{issue['number']}",
+                    "repo_name": repo,
+                    "issue_number": issue["number"],
+                    "issue_state": issue["state"],
+                    "issue_labels": labels[:1024],
+                    "citation_url": issue["html_url"],
+                    "chunk_index": idx,
+                    "content_text": chunk_text,
+                    "vector": embedding,
+                    "last_updated": timestamp,
+                    "source_type": "issue",
+                })
+
+            total_chunks += len(chunks)
+            print(f"  #{issue['number']}: {issue['title'][:60]} ({len(chunks)} chunks, {len(comments)} comments)")
+
+        if records:
+            # Insert in batches of 100
+            for i in range(0, len(records), 100):
+                batch = records[i:i+100]
+                collection.insert(batch)
+            print(f"  Inserted {len(records)} records from {repo}")
+
+    collection.flush()
+
+    # Create index if needed (fresh mode or first run)
+    if not collection.has_index():
+        print("\nCreating vector index...")
+        index_params = {
+            "metric_type": "COSINE",
+            "index_type": "IVF_FLAT",
+            "params": {"nlist": min(1024, max(1, collection.num_entities))},
+        }
+        collection.create_index("vector", index_params)
+    collection.load()
+
+    print(f"\nTotal: {collection.num_entities} chunks from {len(repos)} repos")
+
+    # Sanity search
+    print("\n--- Sanity check: 'pipeline timeout error' ---")
+    q_emb = model.encode("pipeline timeout error").tolist()
+    results = collection.search(
+        data=[q_emb],
+        anns_field="vector",
+        param={"metric_type": "COSINE", "params": {"nprobe": 10}},
+        limit=3,
+        output_fields=["issue_number", "repo_name", "issue_state", "content_text"],
+    )
+    for hits in results:
+        for hit in hits:
+            print(f"  #{hit.entity.get('issue_number')} [{hit.entity.get('repo_name')}] "
+                  f"(score: {hit.distance:.4f}): {hit.entity.get('content_text', '')[:80]}...")
+
+    print("\nDone! issues_rag is ready for search_github_issues MCP tool.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,117 @@
+"""Shared fixtures for docs-agent tests."""
+
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def mock_milvus_client():
+    """Create a mock MilvusClient that returns configurable search results."""
+    client = MagicMock()
+    client.search.return_value = [[]]  # default: no results
+    return client
+
+
+@pytest.fixture
+def mock_sentence_transformer():
+    """Create a mock SentenceTransformer that returns a fixed embedding."""
+    model = MagicMock()
+    # Return a fake 768-dim embedding
+    model.encode.return_value = np.zeros(768, dtype=np.float32)
+    return model
+
+
+@pytest.fixture
+def sample_milvus_hits():
+    """Sample Milvus search results for testing output formatting."""
+    return [[
+        {
+            "id": 1,
+            "distance": 0.9234,
+            "entity": {
+                "content_text": "KServe provides serverless inference on Kubernetes.",
+                "citation_url": "https://www.kubeflow.org/docs/kserve/",
+                "file_path": "content/en/docs/kserve/overview.md",
+            },
+        },
+        {
+            "id": 2,
+            "distance": 0.8567,
+            "entity": {
+                "content_text": "Install Kubeflow Pipelines using the standalone deployment.",
+                "citation_url": "https://www.kubeflow.org/docs/pipelines/install/",
+                "file_path": "content/en/docs/pipelines/install.md",
+            },
+        },
+    ]]
+
+
+@pytest.fixture
+def sample_github_issue_api_response():
+    """Sample GitHub API response for a single issue."""
+    return {
+        "number": 42,
+        "title": "KServe model not loading",
+        "body": "The model fails to load when using GPU.",
+        "state": "open",
+        "html_url": "https://github.com/kubeflow/kubeflow/issues/42",
+        "created_at": "2026-01-15T10:00:00Z",
+        "updated_at": "2026-01-20T14:30:00Z",
+        "labels": [{"name": "kind/bug"}, {"name": "area/kserve"}],
+        "comments": 2,
+        "user": {"login": "testuser"},
+    }
+
+
+@pytest.fixture
+def sample_github_pr_api_response():
+    """Sample GitHub API response that represents a PR (has pull_request key)."""
+    return {
+        "number": 100,
+        "title": "Fix typo in docs",
+        "body": "Fixed a typo.",
+        "state": "closed",
+        "html_url": "https://github.com/kubeflow/kubeflow/pull/100",
+        "created_at": "2026-01-10T10:00:00Z",
+        "updated_at": "2026-01-11T10:00:00Z",
+        "labels": [],
+        "comments": 0,
+        "user": {"login": "contributor"},
+        "pull_request": {
+            "url": "https://api.github.com/repos/kubeflow/kubeflow/pulls/100"
+        },
+    }
+
+
+@pytest.fixture
+def sample_issues_milvus_hits():
+    """Sample Milvus search results from the issues_rag collection."""
+    return [[
+        {
+            "id": 1,
+            "distance": 0.8912,
+            "entity": {
+                "content_text": "[Issue #42] KServe model not loading | Repo: kubeflow/kubeflow\n\nThe model fails to load when using GPU.",
+                "citation_url": "https://github.com/kubeflow/kubeflow/issues/42",
+                "repo_name": "kubeflow/kubeflow",
+                "issue_number": 42,
+                "issue_state": "open",
+                "issue_labels": "kind/bug, area/kserve",
+            },
+        },
+        {
+            "id": 2,
+            "distance": 0.7845,
+            "entity": {
+                "content_text": "[Issue #100] Pipeline timeout on large datasets | Repo: kubeflow/pipelines\n\nPipeline runs time out after 30 minutes.",
+                "citation_url": "https://github.com/kubeflow/pipelines/issues/100",
+                "repo_name": "kubeflow/pipelines",
+                "issue_number": 100,
+                "issue_state": "closed",
+                "issue_labels": "kind/bug",
+            },
+        },
+    ]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Shared fixtures for docs-agent tests."""
 
-import sys
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -27,26 +26,28 @@ def mock_sentence_transformer():
 @pytest.fixture
 def sample_milvus_hits():
     """Sample Milvus search results for testing output formatting."""
-    return [[
-        {
-            "id": 1,
-            "distance": 0.9234,
-            "entity": {
-                "content_text": "KServe provides serverless inference on Kubernetes.",
-                "citation_url": "https://www.kubeflow.org/docs/kserve/",
-                "file_path": "content/en/docs/kserve/overview.md",
+    return [
+        [
+            {
+                "id": 1,
+                "distance": 0.9234,
+                "entity": {
+                    "content_text": "KServe provides serverless inference on Kubernetes.",
+                    "citation_url": "https://www.kubeflow.org/docs/kserve/",
+                    "file_path": "content/en/docs/kserve/overview.md",
+                },
             },
-        },
-        {
-            "id": 2,
-            "distance": 0.8567,
-            "entity": {
-                "content_text": "Install Kubeflow Pipelines using the standalone deployment.",
-                "citation_url": "https://www.kubeflow.org/docs/pipelines/install/",
-                "file_path": "content/en/docs/pipelines/install.md",
+            {
+                "id": 2,
+                "distance": 0.8567,
+                "entity": {
+                    "content_text": "Install Kubeflow Pipelines using the standalone deployment.",
+                    "citation_url": "https://www.kubeflow.org/docs/pipelines/install/",
+                    "file_path": "content/en/docs/pipelines/install.md",
+                },
             },
-        },
-    ]]
+        ]
+    ]
 
 
 @pytest.fixture
@@ -80,38 +81,73 @@ def sample_github_pr_api_response():
         "labels": [],
         "comments": 0,
         "user": {"login": "contributor"},
-        "pull_request": {
-            "url": "https://api.github.com/repos/kubeflow/kubeflow/pulls/100"
-        },
+        "pull_request": {"url": "https://api.github.com/repos/kubeflow/kubeflow/pulls/100"},
     }
 
 
 @pytest.fixture
 def sample_issues_milvus_hits():
     """Sample Milvus search results from the issues_rag collection."""
-    return [[
-        {
-            "id": 1,
-            "distance": 0.8912,
-            "entity": {
-                "content_text": "[Issue #42] KServe model not loading | Repo: kubeflow/kubeflow\n\nThe model fails to load when using GPU.",
-                "citation_url": "https://github.com/kubeflow/kubeflow/issues/42",
-                "repo_name": "kubeflow/kubeflow",
-                "issue_number": 42,
-                "issue_state": "open",
-                "issue_labels": "kind/bug, area/kserve",
+    return [
+        [
+            {
+                "id": 1,
+                "distance": 0.8912,
+                "entity": {
+                    "content_text": "[Issue #42] KServe model not loading | Repo: kubeflow/kubeflow\n\nThe model fails to load when using GPU.",
+                    "citation_url": "https://github.com/kubeflow/kubeflow/issues/42",
+                    "repo_name": "kubeflow/kubeflow",
+                    "issue_number": 42,
+                    "issue_state": "open",
+                    "issue_labels": "kind/bug, area/kserve",
+                },
             },
-        },
-        {
-            "id": 2,
-            "distance": 0.7845,
-            "entity": {
-                "content_text": "[Issue #100] Pipeline timeout on large datasets | Repo: kubeflow/pipelines\n\nPipeline runs time out after 30 minutes.",
-                "citation_url": "https://github.com/kubeflow/pipelines/issues/100",
-                "repo_name": "kubeflow/pipelines",
-                "issue_number": 100,
-                "issue_state": "closed",
-                "issue_labels": "kind/bug",
+            {
+                "id": 2,
+                "distance": 0.7845,
+                "entity": {
+                    "content_text": "[Issue #100] Pipeline timeout on large datasets | Repo: kubeflow/pipelines\n\nPipeline runs time out after 30 minutes.",
+                    "citation_url": "https://github.com/kubeflow/pipelines/issues/100",
+                    "repo_name": "kubeflow/pipelines",
+                    "issue_number": 100,
+                    "issue_state": "closed",
+                    "issue_labels": "kind/bug",
+                },
             },
-        },
-    ]]
+        ]
+    ]
+
+
+@pytest.fixture
+def sample_code_milvus_hits():
+    """Sample Milvus search results from the code_rag collection."""
+    return [
+        [
+            {
+                "id": 1,
+                "distance": 0.8123,
+                "entity": {
+                    "content_text": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: ml-pipeline",
+                    "citation_url": "https://github.com/kubeflow/manifests/blob/main/apps/pipeline/deployment.yaml",
+                    "file_path": "apps/pipeline/deployment.yaml",
+                    "resource_kind": "Deployment",
+                    "resource_name": "ml-pipeline",
+                    "resource_namespace": "kubeflow",
+                    "file_type": "yaml",
+                },
+            },
+            {
+                "id": 2,
+                "distance": 0.7012,
+                "entity": {
+                    "content_text": "def reconcile_component(component):\n    return component",
+                    "citation_url": "https://github.com/kubeflow/pipelines/blob/main/sdk/compiler.py",
+                    "file_path": "sdk/compiler.py",
+                    "resource_kind": "function",
+                    "resource_name": "reconcile_component",
+                    "resource_namespace": "",
+                    "file_type": "python",
+                },
+            },
+        ]
+    ]

--- a/tests/test_code_utils.py
+++ b/tests/test_code_utils.py
@@ -1,0 +1,166 @@
+"""Tests for code and manifest chunking utilities."""
+
+import sys
+from pathlib import Path
+
+
+PIPELINES_DIR = Path(__file__).parent.parent / "pipelines"
+sys.path.insert(0, str(PIPELINES_DIR))
+
+from code_utils import chunk_code_file, parse_json_file, parse_python_ast, parse_yaml_documents
+
+
+class TestParseYamlDocuments:
+    """Tests for Kubernetes YAML-aware chunking."""
+
+    def test_extracts_metadata_from_multi_document_yaml(self):
+        content = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+  namespace: kubeflow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline
+"""
+
+        chunks = parse_yaml_documents(content, "apps/pipeline/deployment.yaml")
+
+        assert len(chunks) == 2
+        assert chunks[0]["resource_kind"] == "Deployment"
+        assert chunks[0]["resource_name"] == "ml-pipeline"
+        assert chunks[0]["resource_namespace"] == "kubeflow"
+        assert chunks[0]["file_type"] == "yaml"
+        assert chunks[1]["resource_kind"] == "Service"
+
+    def test_marks_kustomization_files(self):
+        content = """apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+"""
+
+        chunks = parse_yaml_documents(content, "apps/pipeline/kustomization.yaml")
+
+        assert len(chunks) == 1
+        assert chunks[0]["file_type"] == "kustomize"
+        assert chunks[0]["resource_kind"] == "Kustomization"
+
+    def test_invalid_yaml_falls_back_to_text_chunk(self):
+        content = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}
+data:
+  value: [unterminated
+"""
+
+        chunks = parse_yaml_documents(content, "templates/configmap.yaml")
+
+        assert len(chunks) == 1
+        assert chunks[0]["content"] == content.strip()
+        assert chunks[0]["resource_kind"] == ""
+        assert chunks[0]["file_type"] == "yaml"
+
+
+class TestParsePythonAst:
+    """Tests for Python AST-aware chunking."""
+
+    def test_extracts_header_classes_functions_and_async_functions(self):
+        content = '''"""Module docs."""
+import os
+
+CONSTANT = "value"
+
+@decorator
+def build_pipeline(name):
+    return name
+
+class PipelineCompiler:
+    def compile(self):
+        return True
+
+async def run_pipeline():
+    return "done"
+'''
+
+        chunks = parse_python_ast(content, "sdk/compiler.py")
+
+        kinds_and_names = [(chunk["resource_kind"], chunk["resource_name"]) for chunk in chunks]
+        assert kinds_and_names == [
+            ("module_header", "compiler.py"),
+            ("function", "build_pipeline"),
+            ("class", "PipelineCompiler"),
+            ("async_function", "run_pipeline"),
+        ]
+        assert chunks[1]["content"].startswith("@decorator")
+        assert chunks[1]["file_type"] == "python"
+
+    def test_returns_module_chunk_when_no_top_level_defs(self):
+        content = "PIPELINE_ROOT = '/tmp/pipeline'\nDEFAULT_TIMEOUT = 30\n"
+
+        chunks = parse_python_ast(content, "settings.py")
+
+        assert len(chunks) == 1
+        assert chunks[0]["resource_kind"] == "module"
+        assert chunks[0]["resource_name"] == "settings.py"
+
+    def test_syntax_error_returns_whole_file(self):
+        content = "def broken(:\n    pass\n"
+
+        chunks = parse_python_ast(content, "broken.py")
+
+        assert len(chunks) == 1
+        assert chunks[0]["content"] == content
+        assert chunks[0]["resource_kind"] == ""
+        assert chunks[0]["file_type"] == "python"
+
+
+class TestChunkCodeFile:
+    """Tests for file type routing and oversized chunk behavior."""
+
+    def test_json_file_is_indexed_as_single_chunk(self):
+        content = '{"name": "docs-agent", "private": true}'
+
+        chunks = parse_json_file(content, "package.json")
+
+        assert chunks == [
+            {
+                "content": content,
+                "resource_kind": "",
+                "resource_name": "package.json",
+                "resource_namespace": "",
+                "file_type": "json",
+            }
+        ]
+
+    def test_generic_file_uses_text_fallback(self):
+        content = "FROM python:3.11-slim\nRUN echo hello\n"
+
+        chunks = chunk_code_file(content, "Dockerfile")
+
+        assert len(chunks) == 1
+        assert chunks[0]["resource_name"] == "Dockerfile"
+        assert chunks[0]["file_type"] == "text"
+
+    def test_oversized_yaml_subchunks_preserve_metadata(self):
+        content = (
+            "apiVersion: v1\n"
+            "kind: ConfigMap\n"
+            "metadata:\n"
+            "  name: large-config\n"
+            "  namespace: kubeflow\n"
+            "data:\n"
+            f"  body: {'value ' * 120}\n"
+        )
+
+        chunks = chunk_code_file(content, "manifests/configmap.yaml", chunk_size=120, chunk_overlap=10)
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert chunk["resource_kind"] == "ConfigMap"
+            assert chunk["resource_name"] == "large-config"
+            assert chunk["resource_namespace"] == "kubeflow"
+            assert chunk["file_type"] == "yaml"

--- a/tests/test_issues_pipeline.py
+++ b/tests/test_issues_pipeline.py
@@ -1,0 +1,202 @@
+"""Tests for GitHub issues pipeline utilities (pipelines/issues_utils.py).
+
+Tests the pure-Python metadata parsing and chunking logic extracted
+from the chunk_and_embed_issues KFP component for testability.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PIPELINES_DIR = Path(__file__).parent.parent / "pipelines"
+sys.path.insert(0, str(PIPELINES_DIR))
+
+from issues_utils import parse_issue_metadata, build_metadata_prefix, split_issue_into_chunks
+
+
+# --- Sample content fixtures ---
+
+SAMPLE_ISSUE_CONTENT = """# KServe model not loading
+
+**Repository:** kubeflow/kubeflow
+**Issue:** #42
+**URL:** https://github.com/kubeflow/kubeflow/issues/42
+**Labels:** kind/bug, area/kserve
+**State:** open
+**Created:** 2026-01-15
+**Updated:** 2026-01-20
+
+The model fails to load when using GPU. I've tried multiple configurations
+but keep getting OOM errors.
+
+---
+**Comment by @alice** (2026-01-16):
+Have you tried setting memory limits in your InferenceService spec?
+
+---
+**Comment by @bob** (2026-01-17):
+Fixed by upgrading KServe to v0.12. The GPU memory allocation was improved."""
+
+SHORT_ISSUE_CONTENT = """# Typo in docs
+
+**Repository:** kubeflow/website
+**Issue:** #99
+**URL:** https://github.com/kubeflow/website/issues/99
+**Labels:** kind/docs
+**State:** closed
+**Created:** 2026-02-01
+**Updated:** 2026-02-02
+
+There is a typo on the installation page."""
+
+NO_LABELS_CONTENT = """# Feature request
+
+**Repository:** kubeflow/pipelines
+**Issue:** #500
+**URL:** https://github.com/kubeflow/pipelines/issues/500
+**Labels:**
+**State:** open
+**Created:** 2026-03-01
+**Updated:** 2026-03-10
+
+Please add support for caching."""
+
+
+class TestParseIssueMetadata:
+    """Tests for parse_issue_metadata."""
+
+    def test_extracts_title(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        assert meta["title"] == "KServe model not loading"
+
+    def test_extracts_repo_name(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        assert meta["repo_name"] == "kubeflow/kubeflow"
+
+    def test_extracts_issue_number(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        assert meta["issue_number"] == 42
+
+    def test_extracts_state(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        assert meta["issue_state"] == "open"
+
+    def test_extracts_labels(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        assert meta["issue_labels"] == "kind/bug, area/kserve"
+
+    def test_extracts_citation_url(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        assert meta["citation_url"] == "https://github.com/kubeflow/kubeflow/issues/42"
+
+    def test_handles_empty_labels(self):
+        meta = parse_issue_metadata(NO_LABELS_CONTENT)
+        assert meta["issue_labels"] == ""
+
+    def test_handles_closed_state(self):
+        meta = parse_issue_metadata(SHORT_ISSUE_CONTENT)
+        assert meta["issue_state"] == "closed"
+
+    def test_returns_zero_for_missing_number(self):
+        meta = parse_issue_metadata("No metadata here")
+        assert meta["issue_number"] == 0
+
+    def test_returns_empty_for_missing_fields(self):
+        meta = parse_issue_metadata("Just plain text")
+        assert meta["title"] == ""
+        assert meta["repo_name"] == ""
+        assert meta["citation_url"] == ""
+
+
+class TestBuildMetadataPrefix:
+    """Tests for build_metadata_prefix."""
+
+    def test_includes_issue_number_and_title(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        assert "[Issue #42]" in prefix
+        assert "KServe model not loading" in prefix
+
+    def test_includes_repo(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        assert "Repo: kubeflow/kubeflow" in prefix
+
+    def test_includes_state(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        assert "State: open" in prefix
+
+    def test_includes_labels(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        assert "Labels: kind/bug, area/kserve" in prefix
+
+    def test_omits_empty_labels(self):
+        meta = parse_issue_metadata(NO_LABELS_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        assert "Labels:" not in prefix
+
+    def test_ends_with_double_newline(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        assert prefix.endswith("\n\n")
+
+
+class TestSplitIssueIntoChunks:
+    """Tests for split_issue_into_chunks."""
+
+    def test_short_issue_single_chunk(self):
+        meta = parse_issue_metadata(SHORT_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        chunks = split_issue_into_chunks(SHORT_ISSUE_CONTENT, prefix, chunk_size=2000)
+        assert len(chunks) == 1
+
+    def test_short_issue_has_prefix(self):
+        meta = parse_issue_metadata(SHORT_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        chunks = split_issue_into_chunks(SHORT_ISSUE_CONTENT, prefix, chunk_size=2000)
+        assert chunks[0].startswith("[Issue #99]")
+
+    def test_long_issue_splits_at_comment_boundaries(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        # Use a small chunk_size to force splitting
+        chunks = split_issue_into_chunks(SAMPLE_ISSUE_CONTENT, prefix, chunk_size=300)
+        assert len(chunks) > 1
+
+    def test_every_chunk_has_prefix(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        chunks = split_issue_into_chunks(SAMPLE_ISSUE_CONTENT, prefix, chunk_size=300)
+        for chunk in chunks:
+            assert chunk.startswith("[Issue #42]")
+
+    def test_no_empty_chunks(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        chunks = split_issue_into_chunks(SAMPLE_ISSUE_CONTENT, prefix, chunk_size=300)
+        for chunk in chunks:
+            # Each chunk should have content beyond just the prefix
+            assert len(chunk) > len(prefix)
+
+    def test_issue_with_no_comments(self):
+        meta = parse_issue_metadata(SHORT_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        chunks = split_issue_into_chunks(SHORT_ISSUE_CONTENT, prefix, chunk_size=2000)
+        assert len(chunks) == 1
+        assert "typo" in chunks[0].lower()
+
+    def test_respects_chunk_size(self):
+        meta = parse_issue_metadata(SAMPLE_ISSUE_CONTENT)
+        prefix = build_metadata_prefix(meta)
+        chunk_size = 400
+        chunks = split_issue_into_chunks(SAMPLE_ISSUE_CONTENT, prefix, chunk_size=chunk_size)
+        for chunk in chunks:
+            # Allow some tolerance for the text splitter
+            assert len(chunk) <= chunk_size + 100
+
+    def test_handles_empty_content(self):
+        chunks = split_issue_into_chunks("", "prefix\n\n", chunk_size=1000)
+        assert len(chunks) == 1

--- a/tests/test_issues_pipeline.py
+++ b/tests/test_issues_pipeline.py
@@ -7,8 +7,6 @@ from the chunk_and_embed_issues KFP component for testability.
 import sys
 from pathlib import Path
 
-import pytest
-
 PIPELINES_DIR = Path(__file__).parent.parent / "pipelines"
 sys.path.insert(0, str(PIPELINES_DIR))
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,405 @@
+"""Tests for the MCP server (kagent-feast-mcp/mcp-server/server.py).
+
+Mocking strategy: We pre-populate sys.modules with mock versions of
+sentence_transformers and pymilvus BEFORE importing server.py. This avoids
+loading the real heavy libraries (which take 30s+ and need GPU/model downloads).
+The mocks persist for the lifetime of the test process — this is intentional
+since only the server module references them.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# Add the MCP server directory to the path
+MCP_SERVER_DIR = Path(__file__).parent.parent / "kagent-feast-mcp" / "mcp-server"
+sys.path.insert(0, str(MCP_SERVER_DIR))
+
+# Pre-mock heavy dependencies before importing server.
+# server.py does `from pymilvus import MilvusClient` and
+# `from sentence_transformers import SentenceTransformer` at import time.
+# These mocks are never cleaned up — server retains the mock bindings
+# for the test process lifetime, which is exactly what we want.
+sys.modules.setdefault("sentence_transformers", MagicMock())
+sys.modules.setdefault("pymilvus", MagicMock())
+
+if "server" in sys.modules:
+    del sys.modules["server"]
+import server
+
+
+@pytest.fixture(autouse=True)
+def reset_server_globals():
+    """Reset server globals before each test so state doesn't leak."""
+    original_model = server.model
+    original_client = server.client
+    original_st = server.SentenceTransformer
+    original_mc = server.MilvusClient
+    yield
+    server.model = original_model
+    server.client = original_client
+    server.SentenceTransformer = original_st
+    server.MilvusClient = original_mc
+
+
+@pytest.fixture
+def inject_mocks(mock_milvus_client, mock_sentence_transformer):
+    """Inject mock model and client into the server module."""
+    server.model = mock_sentence_transformer
+    server.client = mock_milvus_client
+    return mock_milvus_client, mock_sentence_transformer
+
+
+class TestInit:
+    """Tests for the _init() lazy initialization function."""
+
+    def test_init_creates_model_and_client_when_none(self):
+        """_init() should create model and client when they are None."""
+        server.model = None
+        server.client = None
+
+        mock_st_class = MagicMock(return_value=MagicMock())
+        mock_mc_class = MagicMock(return_value=MagicMock())
+        server.SentenceTransformer = mock_st_class
+        server.MilvusClient = mock_mc_class
+
+        server._init()
+
+        mock_st_class.assert_called_once_with(server.EMBEDDING_MODEL)
+        mock_mc_class.assert_called_once_with(
+            uri=server.MILVUS_URI,
+            user=server.MILVUS_USER,
+            password=server.MILVUS_PASSWORD,
+        )
+
+    def test_init_is_idempotent(self):
+        """Calling _init() twice should not create duplicate clients."""
+        server.model = None
+        server.client = None
+
+        mock_st_class = MagicMock(return_value=MagicMock())
+        mock_mc_class = MagicMock(return_value=MagicMock())
+        server.SentenceTransformer = mock_st_class
+        server.MilvusClient = mock_mc_class
+
+        server._init()
+        server._init()
+
+        mock_st_class.assert_called_once()
+        mock_mc_class.assert_called_once()
+
+    def test_init_skips_if_already_initialized(self):
+        """_init() should not overwrite existing model/client."""
+        existing_model = MagicMock()
+        existing_client = MagicMock()
+        server.model = existing_model
+        server.client = existing_client
+
+        mock_st_class = MagicMock()
+        mock_mc_class = MagicMock()
+        server.SentenceTransformer = mock_st_class
+        server.MilvusClient = mock_mc_class
+
+        server._init()
+
+        assert server.model is existing_model
+        assert server.client is existing_client
+        mock_st_class.assert_not_called()
+        mock_mc_class.assert_not_called()
+
+
+class TestSearchKubeflowDocs:
+    """Tests for the search_kubeflow_docs MCP tool."""
+
+    def test_returns_no_results_message_when_empty(self, inject_mocks):
+        """Should return 'No results found' when Milvus returns empty."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        result = server.search_kubeflow_docs("test query")
+
+        assert result == "No results found for your query."
+
+    def test_returns_formatted_results(self, inject_mocks, sample_milvus_hits):
+        """Should return markdown-formatted results with scores and citations."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_milvus_hits
+
+        result = server.search_kubeflow_docs("KServe")
+
+        assert "Result 1" in result
+        assert "Result 2" in result
+        assert "0.9234" in result
+        assert "https://www.kubeflow.org/docs/kserve/" in result
+        assert "KServe provides serverless inference" in result
+
+    def test_includes_file_path_in_results(self, inject_mocks, sample_milvus_hits):
+        """Result should include the file path from Milvus."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_milvus_hits
+
+        result = server.search_kubeflow_docs("KServe")
+
+        assert "content/en/docs/kserve/overview.md" in result
+
+    def test_respects_top_k_parameter(self, inject_mocks):
+        """top_k should be passed through to Milvus client.search limit."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_docs("test", top_k=3)
+
+        assert mock_client.search.call_args.kwargs["limit"] == 3
+
+    def test_encodes_query_with_model(self, inject_mocks):
+        """Should encode the query string using the sentence transformer."""
+        mock_client, mock_model = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_docs("KServe setup guide")
+
+        mock_model.encode.assert_called_once_with("KServe setup guide")
+
+    def test_passes_embedding_to_milvus_as_list(self, inject_mocks):
+        """Should pass the encoded embedding as a plain list to Milvus search."""
+        mock_client, mock_model = inject_mocks
+        fake_embedding = np.ones(768, dtype=np.float32)
+        mock_model.encode.return_value = fake_embedding
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_docs("test")
+
+        data = mock_client.search.call_args.kwargs["data"]
+        assert len(data) == 1  # single query vector
+        assert isinstance(data[0], list), "embedding must be a plain list"
+        assert len(data[0]) == 768
+        assert data[0][0] == 1.0  # from np.ones
+
+    def test_requests_correct_output_fields(self, inject_mocks):
+        """Should request content_text, citation_url, and file_path from Milvus."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_docs("test")
+
+        output_fields = mock_client.search.call_args.kwargs["output_fields"]
+        assert "content_text" in output_fields
+        assert "citation_url" in output_fields
+        assert "file_path" in output_fields
+
+    def test_searches_correct_collection(self, inject_mocks):
+        """Should search the configured COLLECTION_NAME."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_docs("test")
+
+        assert mock_client.search.call_args.kwargs["collection_name"] == server.COLLECTION_NAME
+
+    def test_handles_missing_entity_fields_gracefully(self, inject_mocks):
+        """Should handle results where entity fields are missing without crashing."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[
+            {
+                "id": 1,
+                "distance": 0.5,
+                "entity": {},  # no fields
+            }
+        ]]
+
+        result = server.search_kubeflow_docs("test")
+
+        assert "Result 1" in result
+        assert "0.5000" in result
+
+    def test_results_separated_by_divider(self, inject_mocks, sample_milvus_hits):
+        """Multiple results should be separated by --- dividers."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_milvus_hits
+
+        result = server.search_kubeflow_docs("test")
+
+        assert "\n---\n" in result
+
+    def test_default_top_k_is_five(self, inject_mocks):
+        """Default top_k should be 5 when not specified."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_docs("test")
+
+        assert mock_client.search.call_args.kwargs["limit"] == 5
+
+
+class TestSearchCollection:
+    """Tests for the _search_collection shared helper."""
+
+    def test_returns_empty_list_when_no_results(self, inject_mocks):
+        """Should return empty list when Milvus returns no hits."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        result = server._search_collection(
+            collection_name="test_col",
+            query="test",
+            top_k=5,
+            output_fields=["content_text", "citation_url"],
+        )
+        assert result == []
+
+    def test_passes_filter_expr_to_milvus(self, inject_mocks):
+        """Should pass filter expression to Milvus search when provided."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server._search_collection(
+            collection_name="test_col",
+            query="test",
+            top_k=5,
+            output_fields=["content_text", "citation_url"],
+            filter_expr='repo_name == "kubeflow/kubeflow"',
+        )
+
+        assert mock_client.search.call_args.kwargs["filter"] == 'repo_name == "kubeflow/kubeflow"'
+
+    def test_omits_filter_when_empty(self, inject_mocks):
+        """Should not include filter key when filter_expr is empty."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server._search_collection(
+            collection_name="test_col",
+            query="test",
+            top_k=5,
+            output_fields=["content_text", "citation_url"],
+            filter_expr="",
+        )
+
+        assert "filter" not in mock_client.search.call_args.kwargs
+
+    def test_returns_raw_hits_with_entity_data(self, inject_mocks):
+        """Should return raw Milvus hits with entity data intact."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[{
+            "id": 1,
+            "distance": 0.9,
+            "entity": {
+                "content_text": "Test content",
+                "citation_url": "https://example.com",
+                "issue_number": 42,
+            },
+        }]]
+
+        result = server._search_collection(
+            collection_name="test_col",
+            query="test",
+            top_k=5,
+            output_fields=["content_text", "citation_url", "issue_number"],
+        )
+
+        assert len(result) == 1
+        assert result[0]["entity"]["issue_number"] == 42
+        assert result[0]["entity"]["content_text"] == "Test content"
+        assert result[0]["distance"] == 0.9
+
+
+class TestSearchGithubIssues:
+    """Tests for the search_github_issues MCP tool."""
+
+    def test_returns_no_results_when_empty(self, inject_mocks):
+        """Should return 'No issues found' when no issues match."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        result = server.search_github_issues("GPU OOM error")
+        assert result == "No issues found for your query."
+
+    def test_returns_formatted_results(self, inject_mocks, sample_issues_milvus_hits):
+        """Should return formatted results with issue-specific fields."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_issues_milvus_hits
+
+        result = server.search_github_issues("KServe model loading")
+
+        assert "Result 1" in result
+        assert "0.8912" in result
+        assert "github.com/kubeflow/kubeflow/issues/42" in result
+        assert "KServe model not loading" in result
+
+    def test_includes_issue_number(self, inject_mocks, sample_issues_milvus_hits):
+        """Should include issue number in formatted output."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_issues_milvus_hits
+
+        result = server.search_github_issues("test")
+        assert "**Issue:** #42" in result
+
+    def test_includes_issue_labels(self, inject_mocks, sample_issues_milvus_hits):
+        """Should include issue_labels in formatted output."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_issues_milvus_hits
+
+        result = server.search_github_issues("test")
+        assert "kind/bug, area/kserve" in result
+
+    def test_filters_by_repo(self, inject_mocks):
+        """Should construct repo filter expression."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_github_issues("test", repo="kubeflow/pipelines")
+
+        filter_val = mock_client.search.call_args.kwargs.get("filter", "")
+        assert 'repo_name == "kubeflow/pipelines"' in filter_val
+
+    def test_filters_by_state(self, inject_mocks):
+        """Should construct state filter expression."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_github_issues("test", state="open")
+
+        filter_val = mock_client.search.call_args.kwargs.get("filter", "")
+        assert 'issue_state == "open"' in filter_val
+
+    def test_filters_by_repo_and_state(self, inject_mocks):
+        """Should combine repo and state filters with 'and'."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_github_issues("test", repo="kubeflow/kubeflow", state="closed")
+
+        filter_val = mock_client.search.call_args.kwargs["filter"]
+        assert "repo_name" in filter_val
+        assert "issue_state" in filter_val
+        assert " and " in filter_val
+
+    def test_no_filter_when_params_empty(self, inject_mocks):
+        """Should not include filter when repo and state are empty."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_github_issues("test")
+
+        assert "filter" not in mock_client.search.call_args.kwargs
+
+    def test_searches_issues_collection(self, inject_mocks):
+        """Should search the ISSUES_COLLECTION_NAME."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_github_issues("test")
+
+        assert mock_client.search.call_args.kwargs["collection_name"] == server.ISSUES_COLLECTION_NAME
+
+    def test_default_top_k_is_five(self, inject_mocks):
+        """Default top_k should be 5."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_github_issues("test")
+
+        assert mock_client.search.call_args.kwargs["limit"] == 5

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,15 +8,15 @@ since only the server module references them.
 """
 
 import sys
+import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
-# Add the MCP server directory to the path
 MCP_SERVER_DIR = Path(__file__).parent.parent / "kagent-feast-mcp" / "mcp-server"
-sys.path.insert(0, str(MCP_SERVER_DIR))
+MCP_SERVER_PATH = MCP_SERVER_DIR / "server.py"
 
 # Pre-mock heavy dependencies before importing server.
 # server.py does `from pymilvus import MilvusClient` and
@@ -26,9 +26,10 @@ sys.path.insert(0, str(MCP_SERVER_DIR))
 sys.modules.setdefault("sentence_transformers", MagicMock())
 sys.modules.setdefault("pymilvus", MagicMock())
 
-if "server" in sys.modules:
-    del sys.modules["server"]
-import server
+spec = importlib.util.spec_from_file_location("docs_agent_mcp_server", MCP_SERVER_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules["docs_agent_mcp_server"] = server
+spec.loader.exec_module(server)
 
 
 @pytest.fixture(autouse=True)
@@ -202,13 +203,15 @@ class TestSearchKubeflowDocs:
     def test_handles_missing_entity_fields_gracefully(self, inject_mocks):
         """Should handle results where entity fields are missing without crashing."""
         mock_client, _ = inject_mocks
-        mock_client.search.return_value = [[
-            {
-                "id": 1,
-                "distance": 0.5,
-                "entity": {},  # no fields
-            }
-        ]]
+        mock_client.search.return_value = [
+            [
+                {
+                    "id": 1,
+                    "distance": 0.5,
+                    "entity": {},  # no fields
+                }
+            ]
+        ]
 
         result = server.search_kubeflow_docs("test")
 
@@ -283,15 +286,19 @@ class TestSearchCollection:
     def test_returns_raw_hits_with_entity_data(self, inject_mocks):
         """Should return raw Milvus hits with entity data intact."""
         mock_client, _ = inject_mocks
-        mock_client.search.return_value = [[{
-            "id": 1,
-            "distance": 0.9,
-            "entity": {
-                "content_text": "Test content",
-                "citation_url": "https://example.com",
-                "issue_number": 42,
-            },
-        }]]
+        mock_client.search.return_value = [
+            [
+                {
+                    "id": 1,
+                    "distance": 0.9,
+                    "entity": {
+                        "content_text": "Test content",
+                        "citation_url": "https://example.com",
+                        "issue_number": 42,
+                    },
+                }
+            ]
+        ]
 
         result = server._search_collection(
             collection_name="test_col",
@@ -403,3 +410,125 @@ class TestSearchGithubIssues:
         server.search_github_issues("test")
 
         assert mock_client.search.call_args.kwargs["limit"] == 5
+
+    @pytest.mark.parametrize(
+        ("field_name", "kwargs"),
+        [
+            ("repo", {"repo": 'kubeflow/pipelines" or issue_state == "open'}),
+            ("state", {"state": 'open" or repo_name == "kubeflow/kubeflow'}),
+        ],
+    )
+    def test_rejects_unsafe_filter_values(self, inject_mocks, field_name, kwargs):
+        """User-controlled issue filters should not be interpolated unchecked."""
+        mock_client, _ = inject_mocks
+
+        with pytest.raises(ValueError, match=f"Invalid {field_name} filter value"):
+            server.search_github_issues("test", **kwargs)
+
+        mock_client.search.assert_not_called()
+
+
+class TestSearchKubeflowCode:
+    """Tests for the search_kubeflow_code MCP tool."""
+
+    def test_returns_no_results_when_empty(self, inject_mocks):
+        """Should return 'No code results found' when code search is empty."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        result = server.search_kubeflow_code("deployment")
+
+        assert result == "No code results found for your query."
+
+    def test_returns_formatted_code_results(self, inject_mocks, sample_code_milvus_hits):
+        """Should return code results with resource metadata and fenced content."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_code_milvus_hits
+
+        result = server.search_kubeflow_code("pipeline deployment")
+
+        assert "### Result 1 (score: 0.8123)" in result
+        assert "https://github.com/kubeflow/manifests/blob/main/apps/pipeline/deployment.yaml" in result
+        assert "**File:** apps/pipeline/deployment.yaml" in result
+        assert "**Resource:** Deployment `ml-pipeline` (namespace: kubeflow)" in result
+        assert "**Type:** yaml" in result
+        assert "```\napiVersion: apps/v1\nkind: Deployment" in result
+
+    def test_results_separated_by_divider(self, inject_mocks, sample_code_milvus_hits):
+        """Multiple code results should be separated by markdown dividers."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = sample_code_milvus_hits
+
+        result = server.search_kubeflow_code("test")
+
+        assert "\n---\n" in result
+
+    def test_searches_code_collection(self, inject_mocks):
+        """Should search the CODE_COLLECTION_NAME."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_code("test")
+
+        assert mock_client.search.call_args.kwargs["collection_name"] == server.CODE_COLLECTION_NAME
+
+    def test_default_top_k_is_five(self, inject_mocks):
+        """Default top_k should be 5."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_code("test")
+
+        assert mock_client.search.call_args.kwargs["limit"] == 5
+
+    def test_respects_top_k_parameter(self, inject_mocks):
+        """top_k should be passed through to Milvus client.search limit."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_code("test", top_k=2)
+
+        assert mock_client.search.call_args.kwargs["limit"] == 2
+
+    def test_requests_code_output_fields(self, inject_mocks):
+        """Should request code-specific output fields from Milvus."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_code("test")
+
+        output_fields = mock_client.search.call_args.kwargs["output_fields"]
+        assert "content_text" in output_fields
+        assert "citation_url" in output_fields
+        assert "file_path" in output_fields
+        assert "resource_kind" in output_fields
+        assert "resource_name" in output_fields
+        assert "resource_namespace" in output_fields
+        assert "file_type" in output_fields
+
+    def test_filters_by_resource_kind(self, inject_mocks):
+        """Should construct a resource_kind filter expression."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_code("test", resource_kind="Deployment")
+
+        assert mock_client.search.call_args.kwargs["filter"] == "resource_kind == 'Deployment'"
+
+    def test_no_filter_when_resource_kind_empty(self, inject_mocks):
+        """Should not include filter when resource_kind is empty."""
+        mock_client, _ = inject_mocks
+        mock_client.search.return_value = [[]]
+
+        server.search_kubeflow_code("test")
+
+        assert "filter" not in mock_client.search.call_args.kwargs
+
+    def test_rejects_unsafe_resource_kind_filter(self, inject_mocks):
+        """resource_kind should not allow expression injection."""
+        mock_client, _ = inject_mocks
+
+        with pytest.raises(ValueError, match="Invalid resource_kind filter value"):
+            server.search_kubeflow_code("test", resource_kind="Deployment' or file_type == 'python")
+
+        mock_client.search.assert_not_called()

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -1,0 +1,179 @@
+"""Tests for pipeline utility functions and component logic."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add pipelines directory to path
+PIPELINES_DIR = Path(__file__).parent.parent / "pipelines"
+sys.path.insert(0, str(PIPELINES_DIR))
+
+from utils import clean_content
+
+
+class TestCleanContent:
+    """Tests for the clean_content utility function."""
+
+    def test_removes_yaml_frontmatter(self):
+        """Should remove --- delimited YAML frontmatter."""
+        content = "---\ntitle: Test\ndate: 2026-01-01\n---\n\nActual content here."
+        result = clean_content(content)
+        assert "title:" not in result
+        assert "Actual content here." in result
+
+    def test_removes_toml_frontmatter(self):
+        """Should remove +++ delimited TOML frontmatter."""
+        content = "+++\ntitle = 'Test'\n+++\n\nActual content here."
+        result = clean_content(content)
+        assert "title =" not in result
+        assert "Actual content here." in result
+
+    def test_removes_hugo_template_syntax(self):
+        """Should remove {{ ... }} Hugo template expressions."""
+        content = "Install with {{ .Get \"name\" }} command. Then run it."
+        result = clean_content(content)
+        assert "{{" not in result
+        assert "Install with" in result
+        assert "command" in result
+
+    def test_removes_html_comments(self):
+        """Should remove <!-- ... --> HTML comments."""
+        content = "Before <!-- this is a comment --> After"
+        result = clean_content(content)
+        assert "this is a comment" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_removes_html_tags(self):
+        """Should remove HTML tags but keep their text content."""
+        content = "<div class='main'><p>Hello <strong>world</strong></p></div>"
+        result = clean_content(content)
+        assert "<div" not in result
+        assert "<p>" not in result
+        assert "Hello" in result
+        assert "world" in result
+
+    def test_removes_navigation_artifacts(self):
+        """Should remove navigation/menu text artifacts."""
+        content = "Get Started with Kubeflow. Home Menu Navigation overview."
+        result = clean_content(content)
+        assert "Get Started" not in result
+        assert "Menu" not in result
+        assert "Navigation" not in result
+        assert "Kubeflow" in result
+
+    def test_removes_urls(self):
+        """Should remove HTTP/HTTPS URLs."""
+        content = "Visit https://kubeflow.org/docs for more info."
+        result = clean_content(content)
+        assert "https://kubeflow.org" not in result
+        assert "Visit" in result
+        assert "for more info." in result
+
+    def test_converts_markdown_links_to_text(self):
+        """Should convert [text](url) markdown links to just text."""
+        content = "See [the documentation](https://kubeflow.org/docs) for details."
+        result = clean_content(content)
+        assert "the documentation" in result
+        assert "(https://kubeflow.org/docs)" not in result
+
+    def test_normalizes_whitespace(self):
+        """Should collapse multiple spaces into single space."""
+        content = "Hello    world     test"
+        result = clean_content(content)
+        assert "  " not in result
+        assert "Hello world test" in result
+
+    def test_strips_leading_trailing_whitespace(self):
+        """Should strip leading and trailing whitespace."""
+        content = "   Hello world   "
+        result = clean_content(content)
+        assert result == "Hello world"
+
+    def test_returns_empty_for_frontmatter_only(self):
+        """Content that is only frontmatter should return empty string."""
+        content = "---\ntitle: Nothing\ndate: 2026-01-01\n---"
+        result = clean_content(content)
+        assert result == ""
+
+    def test_preserves_meaningful_content(self):
+        """Should not remove meaningful documentation content."""
+        content = (
+            "Kubeflow Pipelines is a platform for building and deploying "
+            "portable, scalable ML workflows based on Docker containers."
+        )
+        result = clean_content(content)
+        assert "Kubeflow Pipelines" in result
+        assert "ML workflows" in result
+        assert "Docker containers" in result
+
+    def test_handles_multiline_html_comment(self):
+        """Should remove HTML comments that span multiple lines."""
+        content = "Before\n<!--\nThis is a\nmulti-line comment\n-->\nAfter"
+        result = clean_content(content)
+        assert "multi-line comment" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_handles_multiline_hugo_template(self):
+        """Should remove Hugo templates that span multiple lines."""
+        content = "Before {{ if .IsHome }}\nstuff\n{{ end }} After"
+        result = clean_content(content)
+        assert "{{ if" not in result
+        assert "{{ end }}" not in result
+
+    def test_real_world_kubeflow_doc_snippet(self):
+        """Test with a realistic Kubeflow documentation snippet."""
+        content = """---
+title: KServe Overview
+description: Overview of KServe
+weight: 1
+---
+
+<!-- This is auto-generated -->
+
+<div class="section-index">
+
+## What is KServe?
+
+[KServe](https://kserve.github.io/website/) enables serverless inference
+on Kubernetes. Visit https://kubeflow.org/docs/external-add-ons/kserve/
+for more details.
+
+{{ partial "section-index.html" . }}
+
+</div>
+"""
+        result = clean_content(content)
+        assert "title:" not in result
+        assert "auto-generated" not in result
+        assert "section-index" not in result
+        assert "KServe" in result
+        assert "serverless inference" in result
+        assert "Kubernetes" in result
+
+
+class TestCleanContentEdgeCases:
+    """Edge cases for content cleaning."""
+
+    def test_empty_string(self):
+        """Should handle empty string input."""
+        assert clean_content("") == ""
+
+    def test_whitespace_only(self):
+        """Should handle whitespace-only input."""
+        assert clean_content("   \n\n  \t  ") == ""
+
+    def test_no_cleaning_needed(self):
+        """Plain text should pass through with minimal changes."""
+        content = "Simple plain text with no special formatting."
+        result = clean_content(content)
+        assert result == content
+
+    def test_nested_html_tags(self):
+        """Should handle deeply nested HTML tags."""
+        content = "<div><div><div><span>Deep content</span></div></div></div>"
+        result = clean_content(content)
+        assert "Deep content" in result
+        assert "<" not in result

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -3,8 +3,6 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add pipelines directory to path
 PIPELINES_DIR = Path(__file__).parent.parent / "pipelines"
 sys.path.insert(0, str(PIPELINES_DIR))
@@ -31,7 +29,7 @@ class TestCleanContent:
 
     def test_removes_hugo_template_syntax(self):
         """Should remove {{ ... }} Hugo template expressions."""
-        content = "Install with {{ .Get \"name\" }} command. Then run it."
+        content = 'Install with {{ .Get "name" }} command. Then run it.'
         result = clean_content(content)
         assert "{{" not in result
         assert "Install with" in result


### PR DESCRIPTION
## Summary

- **71 tests** across 3 modules covering MCP server tools, pipeline utilities, and issue processing
- **GitHub Actions CI** running pytest on Python 3.9, 3.11, 3.12
- **Fast execution** (<4s) — heavy deps (pymilvus, sentence_transformers) mocked at import time, no GPU/model downloads needed

### Test coverage

| Module | Tests | Covers |
|--------|-------|--------|
| `test_mcp_server.py` | 30 | All 3 MCP tools, `_search_collection` helper, `_init()` idempotency, filter params |
| `test_pipeline_utils.py` | 18 | `clean_content()` — Hugo frontmatter, HTML tags, template syntax, edge cases |
| `test_issues_pipeline.py` | 23 | `parse_issue_metadata`, `build_metadata_prefix`, `split_issue_into_chunks` |

### Files added
- `tests/conftest.py` — shared fixtures (mock MilvusClient, SentenceTransformer, sample Milvus hits)
- `tests/test_mcp_server.py`, `tests/test_pipeline_utils.py`, `tests/test_issues_pipeline.py`
- `.github/workflows/tests.yml` — CI workflow
- `requirements-test.txt` — test dependencies

Depends on #205 for the feature code being tested.

## Test plan

- [ ] CI workflow passes on all 3 Python versions
- [ ] `python -m pytest tests/ -v` passes locally (71/71)
- [ ] No real network calls or heavy model downloads in test execution