### PR TITLE
Fix: incremental-pipeline.py can't authenticate to Milvus

### DIFF
--- a/docs-agent-mcp/pipelines/incremental-pipeline.py
+++ b/docs-agent-mcp/pipelines/incremental-pipeline.py
@@ -3,6 +3,11 @@ from kfp import dsl
 from kfp.dsl import *
 from typing import *
 
+try:
+    import kfp.kubernetes as k8s
+except ImportError:  # pragma: no cover - optional at compile time
+    k8s = None
+
 from utils import DOCS_COLLECTION
 
 @dsl.component(
@@ -100,10 +105,22 @@ def delete_old_vectors(
 ):
     from pymilvus import connections, Collection
     import json
-    
+    import os
+
+    milvus_user = os.environ.get("MILVUS_USER", "root")
+    milvus_password = os.environ.get("MILVUS_PASSWORD", "")
+    if not milvus_password:
+        raise RuntimeError("MILVUS_PASSWORD must be set via pipeline secret (not in source code)")
+
     # Connect to Milvus
-    connections.connect("default", host=milvus_host, port=milvus_port)
-    
+    connections.connect(
+        "default",
+        host=milvus_host,
+        port=milvus_port,
+        user=milvus_user,
+        password=milvus_password,
+    )
+
     # Parse file paths
     try:
         file_paths_list = json.loads(file_paths)
@@ -279,9 +296,21 @@ def store_milvus_incremental(
 ):
     from pymilvus import connections, utility, FieldSchema, CollectionSchema, DataType, Collection
     import json
+    import os
     from datetime import datetime
 
-    connections.connect("default", host=milvus_host, port=milvus_port)
+    milvus_user = os.environ.get("MILVUS_USER", "root")
+    milvus_password = os.environ.get("MILVUS_PASSWORD", "")
+    if not milvus_password:
+        raise RuntimeError("MILVUS_PASSWORD must be set via pipeline secret (not in source code)")
+
+    connections.connect(
+        "default",
+        host=milvus_host,
+        port=milvus_port,
+        user=milvus_user,
+        password=milvus_password,
+    )
 
     # Check if collection exists, if not create it
     if not utility.has_collection(collection_name):
@@ -387,7 +416,17 @@ def github_rag_incremental_pipeline(
         milvus_port=milvus_port,
         collection_name=collection_name
     )
-    
+
+    if k8s is not None:
+        k8s.use_secret_as_env(
+            delete_task,
+            secret_name="milvus-auth",
+            secret_key_to_env={
+                "MILVUS_USER": "MILVUS_USER",
+                "MILVUS_PASSWORD": "MILVUS_PASSWORD",
+            },
+        )
+
     # Step 2: Download only the changed files
     download_task = download_specific_files(
         repo_owner=repo_owner,
@@ -413,6 +452,16 @@ def github_rag_incremental_pipeline(
         collection_name=collection_name
     )
     
+    if k8s is not None:
+        k8s.use_secret_as_env(
+            store_task,
+            secret_name="milvus-auth",
+            secret_key_to_env={
+                "MILVUS_USER": "MILVUS_USER",
+                "MILVUS_PASSWORD": "MILVUS_PASSWORD",
+            },
+        )
+
     # Ensure deletion happens before insertion
     store_task.after(delete_task)
 


### PR DESCRIPTION
Both Milvus-touching steps in the incremental pipeline connected with no credentials, unlike every other pipeline in the repo. Verified live against an auth-enabled Milvus - it failed with auth check failure. 

Added MILVUS_USER/MILVUS_PASSWORD handling (same pattern as kubeflow-pipeline.py) and wired the milvus-auth k8s secret into both tasks. 

Lint, compile, and tests all pass.
Fixes: #217 