### PR TITLE
fix: update API server paths in README to point to legacy directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,10 +430,10 @@ data: {"type": "done"}
 3. **Start the API Server**:
    ```bash
    # WebSocket API
-   python server/app.py
+   python legacy/server/app.py
 
    # HTTPS API
-   python server-https/app.py
+   python legacy/server-https/app.py
    ```
 
 ### API Usage Examples


### PR DESCRIPTION
Fixes #225

The `server/` and `server-https/` directories have been moved inside the `legacy/` folder, but the **Usage** section in the `README.md` file still points to the old root paths. This PR updates the startup commands in the README to reflect the correct directory structure by prepending `legacy/` to the paths, preventing `FileNotFoundError` for new users.

[x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that the `legacy/server` and `legacy/server-https` directories exist and the updated paths in the README are now accurate.
