### PR TITLE
fix: inconsistent Milvus hostname default values in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,10 +430,10 @@ data: {"type": "done"}
 3. **Start the API Server**:
    ```bash
    # WebSocket API
-   python server/app.py
+   python legacy/server/app.py
 
    # HTTPS API
-   python server-https/app.py
+   python legacy/server-https/app.py
    ```
 
 ### API Usage Examples

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ if data.get('citations'):
 </tr>
 <tr>
 <td><code>milvus_host</code></td>
-<td><code>milvus-standalone-final.docs-agent.svc.cluster.local</code></td>
+<td><code>my-release-milvus.docs-agent.svc.cluster.local</code></td>
 <td>Milvus host (used by <code>kubeflow-pipeline.py</code> and <code>incremental-pipeline.py</code>)</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Fixes #227

There is a discrepancy in the default hostname provided for Milvus in the `README.md` file. In the **Environment Variables** table, it is `my-release-milvus.docs-agent.svc.cluster.local`, while in the **Pipeline Parameters** table it is `milvus-standalone-final.docs-agent.svc.cluster.local`. This PR unifies the default hostname across both tables to match the provided Helm installation instructions, preventing confusion for new users configuring the pipeline.

[x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that the default values in both configuration tables now match `my-release-milvus.docs-agent.svc.cluster.local`.
